### PR TITLE
Setters for the simple members of the Sam API

### DIFF
--- a/gamgee/sam.h
+++ b/gamgee/sam.h
@@ -47,8 +47,8 @@ class Sam {
   bool supplementary()   const { return m_body.supplementary();   }
 
   // modify flags
-  void mark_as_duplicate()   { m_body.mark_as_duplicate();}
-  void unmark_as_duplicate() { m_body.unmark_as_duplicate();}
+  void set_duplicate()     { m_body.set_duplicate();     }
+  void set_not_duplicate() { m_body.set_not_duplicate(); }
 
   bool empty() const { return m_body.empty(); }
 

--- a/gamgee/sam_body.h
+++ b/gamgee/sam_body.h
@@ -16,20 +16,28 @@ class SamBody {
   SamBody& operator=(const SamBody& other);
   ~SamBody();
 
-  // alignment fields
-  std::string name()              const { return std::string{bam_get_qname(m_body)}; }
-  uint32_t chromosome()           const { return m_body->core.tid; }
-  uint32_t alignment_start()      const { return m_body->core.pos+1; }
+  // getters for non-variable length fields (things outside of the data member)
+  uint32_t chromosome()           const { return m_body->core.tid;     }
+  uint32_t alignment_start()      const { return m_body->core.pos+1;   }
   uint32_t alignment_stop()       const { return bam_endpos(m_body)+1; }
   uint32_t unclipped_start()      const ;
   uint32_t unclipped_stop()       const ;
-  uint32_t mate_chromosome()      const { return m_body->core.mtid; }
+  uint32_t mate_chromosome()      const { return m_body->core.mtid;   }
   uint32_t mate_alignment_start() const { return m_body->core.mpos+1; }
   uint32_t mate_alignment_stop()  const ;                             // not implemented -- requires new mate cigar tag!
   uint32_t mate_unclipped_start() const { return alignment_start(); } // dummy implementation -- requires new mate cigar tag!
   uint32_t mate_unclipped_stop()  const ;                             // not implemented -- requires new mate cigar tag!
 
-  // check flags 
+  // modify non-variable length fields (things outside of the data member)
+  void set_chromosome(const uint32_t chr)           { m_body->core.tid = chr; }
+  void set_alignment_start(const uint32_t start)      { m_body->core.pos = start-1; }  // incoming alignment is 1-based, storing 0-based
+  void set_mate_chromosome(const uint32_t mchr)      { m_body->core.mtid = mchr; }
+  void set_mate_alignment_start(const uint32_t mstart) { m_body->core.mpos = mstart - 1; } // incoming alignment is 1-based, storing 0-based
+ 
+  // getters for fields inside the data field
+  std::string name()              const { return std::string{bam_get_qname(m_body)}; }
+
+  // getters for flags 
   bool paired()          const { return m_body->core.flag & BAM_FPAIRED;        }
   bool properly_paired() const { return m_body->core.flag & BAM_FPROPER_PAIR;   }
   bool unmapped()        const { return m_body->core.flag & BAM_FUNMAP;         }
@@ -42,8 +50,24 @@ class SamBody {
   bool supplementary()   const { return m_body->core.flag & BAM_FSUPPLEMENTARY; }
 
   // modify flags
-  void mark_as_duplicate() {m_body->core.flag |= BAM_FDUP;}
-  void unmark_as_duplicate() {m_body->core.flag &= ~BAM_FDUP;}
+  void set_paired()            { m_body->core.flag |= BAM_FPAIRED;         }
+  void set_not_paired()        { m_body->core.flag &= ~BAM_FPAIRED;        }
+  void set_unmapped()          { m_body->core.flag |= BAM_FUNMAP;          }
+  void set_not_unmapped()      { m_body->core.flag &= ~BAM_FUNMAP;         }
+  void set_next_unmapped()     { m_body->core.flag |= BAM_FMUNMAP;         }
+  void set_not_next_unmapped() { m_body->core.flag &= ~BAM_FMUNMAP;        }
+  void set_first()             { m_body->core.flag |= BAM_FREAD1;          }
+  void set_not_first()         { m_body->core.flag &= ~BAM_FREAD1;         }
+  void set_last()              { m_body->core.flag |= BAM_FREAD2;          }
+  void set_not_last()          { m_body->core.flag &= ~BAM_FREAD2;         }
+  void set_secondary()         { m_body->core.flag |= BAM_FSECONDARY;      }
+  void set_not_secondary()     { m_body->core.flag &= ~BAM_FSECONDARY;     }
+  void set_fail()              { m_body->core.flag |= BAM_FQCFAIL;         }
+  void set_not_fail()          { m_body->core.flag &= ~BAM_FQCFAIL;        }
+  void set_duplicate()         { m_body->core.flag |= BAM_FDUP;            }
+  void set_not_duplicate()     { m_body->core.flag &= ~BAM_FDUP;           }
+  void set_supplementary()     { m_body->core.flag |= BAM_FSUPPLEMENTARY;  }
+  void set_not_supplementary() { m_body->core.flag &= ~BAM_FSUPPLEMENTARY; }
 
   bool empty() const { return m_body->m_data == 0; }
 

--- a/test/sam_body_test.cpp
+++ b/test/sam_body_test.cpp
@@ -1,0 +1,67 @@
+#include <boost/test/unit_test.hpp>
+#include "../gamgee/sam_body.h"
+#include "../gamgee/sam_reader.h"
+
+using namespace std;
+using namespace gamgee;
+
+BOOST_AUTO_TEST_CASE( sam_body_simple_members ) {
+  const auto chr = 5u;
+  const auto aln = 1000u;
+  for (auto s : SamReader<SamIterator> {"testdata/test_simple.bam"}) {  // should be replaced by mock sam_body
+    auto record = s.body();
+    record.set_chromosome(chr);
+    BOOST_CHECK_EQUAL(record.chromosome(), chr);
+    record.set_alignment_start(aln);
+    BOOST_CHECK_EQUAL(record.alignment_start(), aln);
+    record.set_mate_chromosome(chr);
+    BOOST_CHECK_EQUAL(record.mate_chromosome(), chr);
+    record.set_mate_alignment_start(aln);
+    BOOST_CHECK_EQUAL(record.mate_alignment_start(), aln);
+    break;
+  }
+}
+
+BOOST_AUTO_TEST_CASE( sam_body_flags ) 
+{
+  for (auto s : SamReader<SamIterator> {"testdata/test_simple.bam"}) {  // should be replaced by mock sam_body
+    auto record = s.body();
+    record.set_paired();
+    BOOST_CHECK(record.paired());
+    record.set_not_paired();
+    BOOST_CHECK(!record.paired());
+    record.set_unmapped();
+    BOOST_CHECK(record.unmapped());
+    record.set_not_unmapped();
+    BOOST_CHECK(!record.unmapped());
+    record.set_next_unmapped();
+    BOOST_CHECK(record.next_unmapped());
+    record.set_not_next_unmapped();
+    BOOST_CHECK(!record.next_unmapped());
+    record.set_first();
+    BOOST_CHECK(record.first());
+    record.set_not_first();
+    BOOST_CHECK(!record.first());
+    record.set_last();
+    BOOST_CHECK(record.last());
+    record.set_not_last();
+    BOOST_CHECK(!record.last());
+    record.set_secondary();
+    BOOST_CHECK(record.secondary());
+    record.set_not_secondary();
+    BOOST_CHECK(!record.secondary());
+    record.set_fail();
+    BOOST_CHECK(record.fail());
+    record.set_not_fail();
+    BOOST_CHECK(!record.fail());
+    record.set_duplicate();
+    BOOST_CHECK(record.duplicate());
+    record.set_not_duplicate();
+    BOOST_CHECK(!record.duplicate());
+    record.set_supplementary();
+    BOOST_CHECK(record.supplementary());
+    record.set_not_supplementary();
+    BOOST_CHECK(!record.supplementary());
+    break;  // only do this to one read
+  }
+}


### PR DESCRIPTION
only those whose data can be accessed independently inside the bam1_t
and bam_core_t structs. Basically the ones with fixed length.
- add simple members for alignment fields
- add simple flags
- add tests to all functions

this closes #13
