### PR TITLE
Aliases for the sam iterators for ease of use

### DIFF
--- a/gamgee/sam_iterator.h
+++ b/gamgee/sam_iterator.h
@@ -1,9 +1,11 @@
 #ifndef __gamgee__sam_iterator__
 #define __gamgee__sam_iterator__
 
-#include <fstream>
 #include "sam.h"
+
 #include "htslib/sam.h"
+
+#include <fstream>
 
 namespace gamgee {
 

--- a/gamgee/sam_pair_iterator.h
+++ b/gamgee/sam_pair_iterator.h
@@ -1,9 +1,11 @@
 #ifndef __gamgee__sam_pair_iterator__
 #define __gamgee__sam_pair_iterator__
 
-#include <fstream>
 #include "sam.h"
+
 #include "htslib/sam.h"
+
+#include <fstream>
 
 namespace gamgee {
 

--- a/gamgee/sam_reader.h
+++ b/gamgee/sam_reader.h
@@ -1,12 +1,15 @@
 #ifndef gamgee__sam_reader__
 #define gamgee__sam_reader__
 
+#include "sam_iterator.h"
+#include "sam_pair_iterator.h"
+
+#include "htslib/sam.h"
+
 #include <string>
 #include <iostream>
 #include <fstream>
 
-#include "sam_iterator.h"
-#include "htslib/sam.h"  // fix this ! 
 
 namespace gamgee {
 
@@ -17,7 +20,7 @@ namespace gamgee {
  * This class is designed to parse the file in for-each loops with the following signature:
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * for (auto record : SamReader<SamIterator>(filename))
+ * for (auto record : SamReader<SamIterator>{filename})
  *   do_something_with_sam(record);
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
@@ -25,7 +28,13 @@ namespace gamgee {
  * or passing in an empty string for a filename, like so:
  * 
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * for (auto pair : SamReader<SamPairIterator>())
+ * for (auto pair : SamReader<SamPairIterator>{})
+ *   do_something_with_pair(pair);
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * Most iterators have aliases definied by this module so you can use it like so:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * for (auto pair : SingleSamReader{})
  *   do_something_with_pair(pair);
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
@@ -80,6 +89,9 @@ class SamReader {
     samFile *sam_file_ptr;     ///< pointer to the internal file structure of the sam/bam/cram file
     bam_hdr_t *sam_header_ptr; ///< pointer to the internal header structure of the sam/bam/cram file
 };
+
+using SingleSamReader = SamReader<SamIterator>;
+using PairSamReader = SamReader<SamPairIterator>;
 
 }  // end of namespace
 

--- a/test/sam_body_test.cpp
+++ b/test/sam_body_test.cpp
@@ -8,7 +8,7 @@ using namespace gamgee;
 BOOST_AUTO_TEST_CASE( sam_body_simple_members ) {
   const auto chr = 5u;
   const auto aln = 1000u;
-  for (auto record : SamReader<SamIterator> {"testdata/test_simple.bam"}) {  // should be replaced by mock sam_body
+  for (auto record : SingleSamReader {"testdata/test_simple.bam"}) {  // should be replaced by mock sam_body
     record.set_chromosome(chr);
     BOOST_CHECK_EQUAL(record.chromosome(), chr);
     record.set_alignment_start(aln);
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE( sam_body_simple_members ) {
 
 BOOST_AUTO_TEST_CASE( sam_body_flags ) 
 {
-  for (auto record : SamReader<SamIterator> {"testdata/test_simple.bam"}) {  // should be replaced by mock sam_body
+  for (auto record : SingleSamReader {"testdata/test_simple.bam"}) {  // should be replaced by mock sam_body
     record.set_paired();
     BOOST_CHECK(record.paired());
     record.set_not_paired();

--- a/test/sam_reader_test.cpp
+++ b/test/sam_reader_test.cpp
@@ -6,7 +6,7 @@ using namespace gamgee;
 
 BOOST_AUTO_TEST_CASE( read_bam ) 
 {
-    SamReader<SamIterator> reader{"testdata/test_simple.bam"};  // todo -- add sam/cram/vcf/bcf tests as well
+    SingleSamReader reader{"testdata/test_simple.bam"};  // todo -- add sam/cram/vcf/bcf tests as well
     auto counter = 0u;
     for (const auto& sam : reader) {
         BOOST_CHECK_EQUAL(sam.name().substr(0, 15), "30PPJAAXX090125");


### PR DESCRIPTION
The SamReader library is now fully contained of all the iterators and it
comes with readable aliases for SingleSamReader and PairSamReader.

This closes #17
