### PR TITLE
Fix SamPairIterator

### DIFF
--- a/gamgee/sam_pair_iterator.cpp
+++ b/gamgee/sam_pair_iterator.cpp
@@ -1,7 +1,10 @@
 #include "sam_pair_iterator.h"
 #include "sam.h"
 
+#include "htslib/sam.h"
+
 #include <iostream>
+#include <queue>
 
 using namespace std;
 
@@ -10,15 +13,14 @@ namespace gamgee {
 SamPairIterator::SamPairIterator() :
   sam_file_ptr {nullptr},
   sam_header_ptr {nullptr},
-  sam_record_ptr {nullptr},
-  sam_records {}
+  sam_record_ptr {nullptr}
 {}
 
 SamPairIterator::SamPairIterator(samFile * sam_file_ptr_, bam_hdr_t * sam_header_ptr_) : 
   sam_file_ptr {sam_file_ptr_},
   sam_header_ptr {sam_header_ptr_},
   sam_record_ptr {bam_init1()}, ///< important to initialize the record buffer in the constructor so we can reuse it across the iterator
-  sam_records {fetch_next_pair()}
+  sam_records {fetch_next_pair()} ///< important queue must be initialized *before* we call fetch_next_pair. Order matters
 {}
 
 SamPairIterator::SamPairIterator(SamPairIterator&& original) :
@@ -65,12 +67,23 @@ Sam SamPairIterator::make_sam() {
 }
 
 pair<Sam,Sam> SamPairIterator::fetch_next_pair() {
+  if (!supp_alignments.empty()) {
+    const Sam read = supp_alignments.front();
+    supp_alignments.pop();
+    return make_pair(read, Sam{});
+  }
   if (!read_sam()) 
     return make_pair(Sam{}, Sam{});
   const auto read1 = Sam {sam_header_ptr, sam_record_ptr};
-  if (!read1.paired() || !read_sam())
+  if (!read1.paired() || read1.secondary() || read1.supplementary() || !read_sam())
     return make_pair(read1, Sam{});
   const auto read2 = Sam {sam_header_ptr, sam_record_ptr};
+  // clog << "FETCH: " << read1.unmapped() << read1.secondary() << read1.supplementary() << read2.unmapped() << read2.secondary() << read2.supplementary() << "\t" << read1.name() << "\t" << read2.name() << endl;
+  if (!read2.secondary() && !read2.supplementary())
+    return make_pair(read1, read2);
+  supp_alignments.push(read2);
+  while (read_sam() && (sam_record_ptr->core.flag & BAM_FSECONDARY || sam_record_ptr->core.flag & BAM_FSUPPLEMENTARY)) 
+    supp_alignments.push(Sam{sam_header_ptr, sam_record_ptr});
   return make_pair(read1, Sam{sam_header_ptr, sam_record_ptr});
 }
 

--- a/gamgee/sam_pair_iterator.h
+++ b/gamgee/sam_pair_iterator.h
@@ -6,6 +6,7 @@
 #include "htslib/sam.h"
 
 #include <fstream>
+#include <queue>
 
 namespace gamgee {
 
@@ -64,6 +65,7 @@ class SamPairIterator {
     ~SamPairIterator();
     
   private:
+    std::queue<Sam> supp_alignments;      ///< queue to hold the supplementary alignments temporarily while processing the pairs
     samFile * sam_file_ptr;               ///< pointer to the sam file
     bam_hdr_t * sam_header_ptr;           ///< pointer to the sam header
     bam1_t * sam_record_ptr;              ///< pointer to the internal structure of the sam record. Useful to only allocate it once.


### PR DESCRIPTION
## Problem

paired iterator was not taking into account supplementary or secondary alignments.
## Solution

use a queue for all non-primary alignments and pass them through
individually after the properly paired reads.
