### PR TITLE
Refactor SamPairIterator

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -17,7 +17,7 @@ flags = [
 # a "-std=<something>".
 # For a C project, you would set this to something like 'c99' instead of
 # 'c++11'.
-'-std=c++11',
+'-std=c++1y',
 # ...and the same thing goes for the magic -x option which specifies the
 # language that the files to be compiled are written in. This is mostly
 # relevant for c++ headers.
@@ -28,7 +28,7 @@ flags = [
 '-isystem', '/usr/local/include',
 '-isystem', '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1',
 '-isystem', '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include',
-'-I', 'gamgee'
+'-I', 'gamgee',
 '-I', 'lib/htslib'
 ]
 

--- a/gamgee/sam_body.h
+++ b/gamgee/sam_body.h
@@ -17,23 +17,23 @@ class SamBody {
   ~SamBody();
 
   // getters for non-variable length fields (things outside of the data member)
-  uint32_t chromosome()           const { return m_body->core.tid;     }
-  uint32_t alignment_start()      const { return m_body->core.pos+1;   }
-  uint32_t alignment_stop()       const { return bam_endpos(m_body)+1; }
+  uint32_t chromosome()           const { return uint32_t(m_body->core.tid);     }
+  uint32_t alignment_start()      const { return uint32_t(m_body->core.pos+1);   }
+  uint32_t alignment_stop()       const { return uint32_t(bam_endpos(m_body)+1); }
   uint32_t unclipped_start()      const ;
   uint32_t unclipped_stop()       const ;
-  uint32_t mate_chromosome()      const { return m_body->core.mtid;   }
-  uint32_t mate_alignment_start() const { return m_body->core.mpos+1; }
-  uint32_t mate_alignment_stop()  const ;                             // not implemented -- requires new mate cigar tag!
-  uint32_t mate_unclipped_start() const { return alignment_start(); } // dummy implementation -- requires new mate cigar tag!
-  uint32_t mate_unclipped_stop()  const ;                             // not implemented -- requires new mate cigar tag!
+  uint32_t mate_chromosome()      const { return uint32_t(m_body->core.mtid);    }
+  uint32_t mate_alignment_start() const { return uint32_t(m_body->core.mpos+1);  }
+  uint32_t mate_alignment_stop()  const ;                                          // not implemented -- requires new mate cigar tag!
+  uint32_t mate_unclipped_start() const { return alignment_start();              } // dummy implementation -- requires new mate cigar tag!
+  uint32_t mate_unclipped_stop()  const ;                                          // not implemented -- requires new mate cigar tag!
 
   // modify non-variable length fields (things outside of the data member)
-  void set_chromosome(const uint32_t chr)           { m_body->core.tid = chr; }
-  void set_alignment_start(const uint32_t start)      { m_body->core.pos = start-1; }  // incoming alignment is 1-based, storing 0-based
-  void set_mate_chromosome(const uint32_t mchr)      { m_body->core.mtid = mchr; }
-  void set_mate_alignment_start(const uint32_t mstart) { m_body->core.mpos = mstart - 1; } // incoming alignment is 1-based, storing 0-based
- 
+  void set_chromosome(const uint32_t chr)              { m_body->core.tid  = int32_t(chr);        }
+  void set_alignment_start(const uint32_t start)       { m_body->core.pos  = int32_t(start-1);    } // incoming alignment is 1-based, storing 0-based
+  void set_mate_chromosome(const uint32_t mchr)        { m_body->core.mtid = int32_t(mchr);       }
+  void set_mate_alignment_start(const uint32_t mstart) { m_body->core.mpos = int32_t(mstart - 1); } // incoming alignment is 1-based, storing 0-based
+
   // getters for fields inside the data field
   std::string name()              const { return std::string{bam_get_qname(m_body)}; }
 


### PR DESCRIPTION
- refactor fetch_next_pair for clarity and reduce duplication
- switch to unique_ptr queue to avoid moving the header around
- make int conversions explicit between gamgee and htslib (to avoid warnings in the SamPairIterator)
