### PR TITLE
Performance improvements on sam records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ bin/
 
 # doxygen directory
 dox/
+
+# vim temporaries
+*.swp

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Gamgee
 ======
 
+Project website: http://mauriciocarneiro.github.io/gamgee/
+
 A C++ interface for key next generation sequencing file formats. This library
 provides an API for handilng SAM, BAM, CRAM, VCF, BCF, BED, intervals and
 interval_list files.

--- a/gamgee/hts_memory.h
+++ b/gamgee/hts_memory.h
@@ -1,0 +1,31 @@
+#ifndef __gamgee_hts_memory__
+#define __gamgee_hts_memory__
+
+#include "sam.h"
+
+/**
+ * @brief private namespace to contain htslib specific wrappers
+ */
+namespace gamgee {
+
+
+/** 
+ * @brief a functor object to delete a bam1_t pointer 
+ * 
+ * used by the unique_ptr queue used in the paired reader
+ */
+struct BamDeleter {
+  void operator()(bam1_t* p) const { bam_destroy1(p); }
+};
+
+/** 
+ * @brief a functor object to delete a bam_hdr_t pointer 
+ */
+struct HeaderDeleter {
+  void operator()(bam_hdr_t* p) const { bam_hdr_destroy(p); }
+};
+
+}
+
+
+#endif

--- a/gamgee/sam.h
+++ b/gamgee/sam.h
@@ -3,20 +3,26 @@
 
 #include "sam_header.h"
 #include "sam_body.h"
+#include "hts_memory.h"
 
 #include "htslib/sam.h"
 
 #include <string>
+#include <memory>
 
 namespace gamgee {
 
 /**
  * @brief Utility class to manipulate a Sam record.
  */
-class Sam : public SamHeader , public SamBody {
+class Sam : public SamBody {
  public:
   explicit Sam() = default;
-  Sam(const bam_hdr_t* header, const bam1_t* body) : SamHeader{header} , SamBody{body} {}
+  Sam(bam1_t* body, const std::shared_ptr<bam_hdr_t>& header) noexcept : SamBody{body}, m_header{header} {}
+  SamHeader header() { return SamHeader{m_header.get()};}
+
+ private:
+  std::shared_ptr<bam_hdr_t> m_header;
 };
 
 }  // end of namespace

--- a/gamgee/sam_body.cpp
+++ b/gamgee/sam_body.cpp
@@ -6,35 +6,64 @@
 
 namespace gamgee {
 
+  /**
+   * @brief creates an empty sam record and allocates memory for all the fields 
+   * @note This constructor gives the object full ownership of the allocated memory. 
+   */
   SamBody::SamBody() :
-    m_body {bam_init1()}
+    m_body {bam_init1()},
+    m_must_destroy_body {true}
   {}
 
-  SamBody::SamBody(const bam1_t* body) :
-    m_body {bam_init1()}
-  {
-    bam_copy1(m_body, body);
-  }
+  /**
+   * @brief creates a sam record that points to the htslib memory already allocated
+   * @warning this constructor takes no ownership of the allocated data and is intended for higher performance in the usual case. If you need to take ownership of the data, call the copy_internal_record() member function.
+   */
+  SamBody::SamBody(bam1_t* body) :
+    m_body {body},
+    m_must_destroy_body {false}
+  {}
 
+  /**
+   * @brief deep copy of the given sam record
+   * @note This constructor gives the object full ownership of the allocated memory. 
+   */
   SamBody::SamBody(const SamBody& other) :
-    m_body {bam_init1()}
+    m_body {bam_init1()},
+    m_must_destroy_body{true}
   {
     bam_copy1(m_body, other.m_body);
   }
 
+  /**
+   * @brief takes over the ownership status of the other object as is (whether or not it owned anything)
+   */
   SamBody::SamBody(SamBody&& other) :
-    m_body {other.m_body}
+    m_body {other.m_body},
+    m_must_destroy_body {other.m_must_destroy_body}
   {
     other.m_body = nullptr;
   }
 
+  /**
+   * @brief deep copy of the given sam record
+   * @note This constructor gives the object full ownership of the allocated memory and appropriately 
+   * manages any already existing internal data.
+   */
   SamBody& SamBody::operator=(const SamBody& other) {
-    bam_copy1(m_body, other.m_body);
+    if (!m_must_destroy_body)             ///< if this record was only pointing to someone else's body before, we need to allocate it's own
+      copy_internal_record(other.m_body);
+    else                                  ///< but if it already held it's own data, we can just copy over it
+      bam_copy1(m_body, other.m_body);
     return *this;
   }
 
+  /**
+   * @brief destroys all htslib internal data if we own it
+   */
   SamBody::~SamBody() {
-    bam_destroy1(m_body);
+    if (m_must_destroy_body)
+      bam_destroy1(m_body);
   }
 
   /**
@@ -83,5 +112,27 @@ namespace gamgee {
     return pos;
   }
 
+  /** 
+   * @brief takes ownership of the objects inside the record
+   *
+   * particularly useful if you are using an iterator (hence storing only weak
+   * pointers to their data) and for some record you decide to keep it beyond
+   * it's lifetime during the iteration. This function will create internal
+   * copies of the data and destroy it accordingly when the object goes out of
+   * scope (destructor)
+   */
+  void SamBody::make_internal_copy() { 
+    if (m_must_destroy_body)  
+      return;                     ///< we already own it!
+    copy_internal_record(m_body);
+  }
+
+  void SamBody::copy_internal_record(const bam1_t* record) {
+    m_body = bam_init1();
+    bam_copy1(m_body, record);
+    m_must_destroy_body = true; ///< takes ownership of the memory and tells the destructor so
+  }
+
 
 }
+

--- a/gamgee/sam_body.h
+++ b/gamgee/sam_body.h
@@ -10,7 +10,7 @@ namespace gamgee {
 class SamBody {
  public:
   explicit SamBody();
-  SamBody(const bam1_t* body);
+  SamBody(bam1_t* body);
   SamBody(const SamBody& other);
   SamBody(SamBody&& other);
   SamBody& operator=(const SamBody& other);
@@ -77,8 +77,12 @@ class SamBody {
 
   bool empty() const { return m_body->m_data == 0; }
 
+  void make_internal_copy();
  private:
   bam1_t* m_body;
+  bool m_must_destroy_body;
+
+  void copy_internal_record(const bam1_t*);
 
   friend class SamWriter;
 };

--- a/gamgee/sam_iterator.h
+++ b/gamgee/sam_iterator.h
@@ -5,7 +5,7 @@
 
 #include "htslib/sam.h"
 
-#include <fstream>
+#include <memory>
 
 namespace gamgee {
 
@@ -26,7 +26,7 @@ class SamIterator {
      * @param sam_file_ptr   pointer to a sam file opened via the sam_open() macro from htslib
      * @param sam_header_ptr pointer to a sam file header created with the sam_hdr_read() macro from htslib
      */
-    SamIterator(samFile * sam_file_ptr, bam_hdr_t * sam_header_ptr);
+    SamIterator(samFile* sam_file_ptr, const std::shared_ptr<bam_hdr_t>& sam_header_ptr);
 
     /**
      * @brief a SamIterator move constructor guarantees all objects will have the same state.
@@ -48,7 +48,7 @@ class SamIterator {
      *
      * @return a persistent Sam object independent from the iterator (a copy of the iterator's object)
      */
-    Sam operator*();
+    Sam& operator*();
 
     /**
      * @brief pre-fetches the next record and tests for end of file
@@ -56,7 +56,7 @@ class SamIterator {
      * @return a reference to the object (it can be const& because this return value should only be used 
      *         by the for-each loop to check for the eof)
      */
-    Sam operator++();
+    Sam& operator++();
 
     /**
      * @brief takes care of all the memory allocations of the htslib sam reader interface
@@ -64,12 +64,12 @@ class SamIterator {
     ~SamIterator();
     
   private:
-    samFile * sam_file_ptr;     ///< pointer to the sam file
-    bam_hdr_t * sam_header_ptr; ///< pointer to the sam header
-    bam1_t * sam_record_ptr;    ///< pointer to the internal structure of the sam record. Useful to only allocate it once.
-    Sam sam_record;             ///< temporary record to hold between fetch (operator++) and serve (operator*)
-    
-    Sam fetch_next_record();    ///< makes a new (through copy) Sam object that the user is free to use/keep without having to worry about memory management
+    samFile * m_sam_file_ptr;                    ///< pointer to the sam file
+    std::shared_ptr<bam_hdr_t> m_sam_header_ptr; ///< pointer to the sam header
+    bam1_t * m_sam_record_ptr;                   ///< pointer to the internal structure of the sam record. Useful to only allocate it once.
+    Sam m_sam_record;                            ///< temporary record to hold between fetch (operator++) and serve (operator*)
+
+    Sam fetch_next_record();                     ///< makes a new (through copy) Sam object that the user is free to use/keep without having to worry about memory management
 };
 
 }  // end namespace gamgee

--- a/gamgee/sam_pair_iterator.cpp
+++ b/gamgee/sam_pair_iterator.cpp
@@ -12,89 +12,92 @@ using namespace std;
 namespace gamgee {
 
 SamPairIterator::SamPairIterator() :
-  sam_file_ptr {nullptr},
-  sam_header_ptr {nullptr},
-  sam_record_ptr {nullptr}
+  m_sam_file_ptr    {nullptr},
+  m_sam_header_ptr  {nullptr},
+  m_sam_record_ptr1 {nullptr},
+  m_sam_record_ptr2 {nullptr}
 {}
 
-SamPairIterator::SamPairIterator(samFile * sam_file_ptr_, bam_hdr_t * sam_header_ptr_) : 
-  sam_file_ptr {sam_file_ptr_},
-  sam_header_ptr {sam_header_ptr_},
-  sam_record_ptr {bam_init1()}, ///< important to initialize the record buffer in the constructor so we can reuse it across the iterator
-  sam_records {fetch_next_pair()} ///< important queue must be initialized *before* we call fetch_next_pair. Order matters
+SamPairIterator::SamPairIterator(samFile * sam_file_ptr, const std::shared_ptr<bam_hdr_t>& sam_header_ptr) : 
+  m_sam_file_ptr    {sam_file_ptr},
+  m_sam_header_ptr  {sam_header_ptr},
+  m_sam_record_ptr1 {bam_init1()}, ///< important to initialize the record buffer in the constructor so we can reuse it across the iterator
+  m_sam_record_ptr2 {bam_init1()}, ///< important to initialize the record buffer in the constructor so we can reuse it across the iterator
+  m_sam_records     {fetch_next_pair()} ///< important queue must be initialized *before* we call fetch_next_pair. Order matters
 {}
 
 SamPairIterator::SamPairIterator(SamPairIterator&& original) :
-  sam_file_ptr {original.sam_file_ptr},
-  sam_header_ptr {original.sam_header_ptr},
-  sam_record_ptr {original.sam_record_ptr},
-  sam_records {original.sam_records}
+  m_sam_file_ptr    {original.m_sam_file_ptr},
+  m_sam_header_ptr  {move(original.m_sam_header_ptr)},
+  m_sam_record_ptr1 {original.m_sam_record_ptr1},
+  m_sam_record_ptr2 {original.m_sam_record_ptr2},
+  m_sam_records     {move(original.m_sam_records)}
 {
-  original.sam_file_ptr = nullptr;
-  original.sam_header_ptr = nullptr;
-  original.sam_record_ptr = nullptr;
+  original.m_sam_file_ptr = nullptr;
+  original.m_sam_record_ptr1 = nullptr;
+  original.m_sam_record_ptr2 = nullptr;
 }
 
 SamPairIterator::~SamPairIterator() {
-  bam_destroy1(sam_record_ptr);
-  sam_file_ptr = nullptr;
-  sam_header_ptr = nullptr;
+  bam_destroy1(m_sam_record_ptr1);
+  bam_destroy1(m_sam_record_ptr2);
+  m_sam_file_ptr = nullptr;
 }
 
 pair<Sam,Sam> SamPairIterator::operator*() {
-  return sam_records;
+  return m_sam_records;
 }
 
 pair<Sam,Sam> SamPairIterator::operator++() {
-  sam_records = fetch_next_pair();
-  return sam_records;
+  m_sam_records = fetch_next_pair();
+  return m_sam_records;
 }
 
 bool SamPairIterator::operator!=(const SamPairIterator& rhs) {
-  return sam_file_ptr != rhs.sam_file_ptr;
+  return m_sam_file_ptr != rhs.m_sam_file_ptr;
 }
 
-bool SamPairIterator::read_sam() {
-  if (sam_read1(sam_file_ptr, sam_header_ptr, sam_record_ptr) < 0) {
-    sam_file_ptr = nullptr;
-    sam_header_ptr = nullptr;  // can only nullify these two because the SamReader is responsible for freeing them. 
+bool SamPairIterator::read_sam(bam1_t* record_ptr) {
+  if (sam_read1(m_sam_file_ptr, m_sam_header_ptr.get(), record_ptr) < 0) {
+    m_sam_file_ptr = nullptr;
     return false;
   }
   return true;
 }
 
-Sam SamPairIterator::make_sam() {
-  return Sam {sam_header_ptr, sam_record_ptr};
+Sam SamPairIterator::make_sam(bam1_t* record_ptr) {
+  return Sam {record_ptr, m_sam_header_ptr};
 }
 
-Sam SamPairIterator::next_primary_alignment() {
-  supp_alignments.emplace(bam_dup1(sam_record_ptr));
-  while (read_sam() && not_primary()) 
-    supp_alignments.emplace(bam_dup1(sam_record_ptr));
-  return make_sam();
+static bool primary(bam1_t* record_ptr) {
+  return record_ptr->core.flag & BAM_FSECONDARY || record_ptr->core.flag & BAM_FSUPPLEMENTARY;
+}
+
+Sam SamPairIterator::next_primary_alignment(bam1_t* record_ptr) {
+  m_supp_alignments.emplace(bam_dup1(record_ptr));
+  while (read_sam(record_ptr) && !primary(record_ptr)) 
+    m_supp_alignments.emplace(bam_dup1(record_ptr));
+  return make_sam(record_ptr);
 }
 
 pair<Sam,Sam> SamPairIterator::next_supplementary_alignment() {
-  const auto read = Sam{sam_header_ptr, supp_alignments.front().get()};
-  supp_alignments.pop();
+  auto read = Sam{m_supp_alignments.front().get(), m_sam_header_ptr};
+  read.make_internal_copy(); ///< todo -- we have to make a copy here because the queue doesn't keep track of the memory allocated for the sam_record_ptr. Make a copy just for now, but we need a better mechanism here
+  m_supp_alignments.pop();
   return make_pair(read, Sam{});
 }
 
-bool SamPairIterator::not_primary() const {
-  return sam_record_ptr->core.flag & BAM_FSECONDARY || sam_record_ptr->core.flag & BAM_FSUPPLEMENTARY;
-}
-
 pair<Sam,Sam> SamPairIterator::fetch_next_pair() {
-  if (!supp_alignments.empty())                        // pending supplementary alignments have priority
+  if (!m_supp_alignments.empty())                                                     // pending supplementary alignments have priority
     return next_supplementary_alignment();
-  if (!read_sam())
-    return make_pair(Sam{}, Sam{});                    // we have reached the end of file
-  const auto read1 = make_sam();
-  if (not_primary() || !read1.paired() || !read_sam()) // unpaired reads go in immediately and by themselves
+  if (!read_sam(m_sam_record_ptr1))
+    return make_pair(Sam{}, Sam{});                                                   // we have reached the end of file
+  const auto read1 = make_sam(m_sam_record_ptr1);
+  if (!primary(m_sam_record_ptr1) || !read1.paired() || !read_sam(m_sam_record_ptr2)) // unpaired reads go in immediately and by themselves
     return make_pair(read1, Sam{});
-  if (!not_primary())                                  // proper paired alignments return here
-    return make_pair(read1, make_sam());
-  return make_pair(read1, next_primary_alignment());   // still haven't found the second primary alignment so search for it while pushing all the secondary/supplementary alignments to the queue
+  if (primary(m_sam_record_ptr2))                                                     // proper paired alignments return here
+    return make_pair(read1, make_sam(m_sam_record_ptr2));
+  return make_pair(read1, next_primary_alignment(m_sam_record_ptr2));                 // still haven't found the second primary alignment so search for it while pushing all the secondary/supplementary alignments to the queue
 }
 
 }

--- a/gamgee/sam_writer.cpp
+++ b/gamgee/sam_writer.cpp
@@ -3,21 +3,24 @@
 namespace gamgee {
 
 SamWriter::SamWriter(const std::string& output_fname, const bool binary) :
-  m_out_file {open_file(output_fname, binary ? "wb" : "w")}
-{}
-
-SamWriter::SamWriter(const SamHeader& sam, const std::string& output_fname, const bool binary) :
   m_out_file {open_file(output_fname, binary ? "wb" : "w")},
-  m_header{sam}
+  m_header {nullptr}
 {}
 
-void SamWriter::add_header(const SamHeader& header) { 
-  m_header = SamHeader{header};
-  sam_hdr_write(m_out_file, m_header.m_header); 
+SamWriter::SamWriter(const SamHeader& header, const std::string& output_fname, const bool binary) :
+  m_out_file {open_file(output_fname, binary ? "wb" : "w")},
+  m_header{header}
+{
+  write_header();
 }
 
 SamWriter::~SamWriter() {
   sam_close(m_out_file);
+}
+
+void SamWriter::add_header(const SamHeader& header) { 
+  m_header = header;
+  write_header();
 }
 
 void SamWriter::add_record(const SamBody& body) { 
@@ -27,5 +30,10 @@ void SamWriter::add_record(const SamBody& body) {
 htsFile* SamWriter::open_file(const std::string& output_fname, const std::string& mode) {
   return hts_open(output_fname.empty() ? "-" : output_fname.c_str(), mode.c_str());
 }
+
+void SamWriter::write_header() const {
+  sam_hdr_write(m_out_file, m_header.m_header); 
+}
+
 
 }

--- a/gamgee/sam_writer.h
+++ b/gamgee/sam_writer.h
@@ -12,19 +12,21 @@ namespace gamgee {
 class SamWriter {
 
  public: 
-   /**
-    * @brief Creates a new SamWriter using the specified output file name
-    *
-    * @param output_fname file to write to. The default is stdout (as defined by htslib)
-    */
+
+  /**
+   * @brief Creates a new SamWriter using the specified output file name
+   * @param output_fname file to write to. The default is stdout (as defined by htslib)
+   * @param binary whether the output should be in BAM (true) or SAM format (false) 
+   * @note the header is copied and managed internally
+   */
   explicit SamWriter(const std::string& output_fname = "-", const bool binary = true);
 
   /**
-   * @brief Creates a new SamWriter with the header extracted from a Sam record and 
-   * using the specified output file name
-   *
-   * @param sam_record   Sam record to extract the header from
+   * @brief Creates a new SamWriter with the header extracted from a Sam record and using the specified output file name
+   * @param header       SamHeader object to make a copy from
    * @param output_fname file to write to. The default is stdout  (as defined by htslib)
+   * @param binary whether the output should be in BAM (true) or SAM format (false) 
+   * @note the header is copied and managed internally
    */
   explicit SamWriter(const SamHeader& header, const std::string& output_fname = "-", const bool binary = true);
 
@@ -38,6 +40,7 @@ class SamWriter {
   SamHeader m_header;
 
   static htsFile* open_file(const std::string& output_fname, const std::string& binary);
+  void write_header() const;
 
 };
 


### PR DESCRIPTION
- strip away header from sam records
- make sam records hold pointers to the body unless copy constructor explicitly called
- modify iterators to own the memory allocation of the objects returned at each iteration
- explicitly tell users that the life of objects returned by reference is limited to the next iteration. Users can opt in on the copy constructor.
- add project website to the README

close #26 
