### PR TITLE
Initial support for variable-length data fields + new shared memory model

### DIFF
--- a/gamgee/base_quals.cpp
+++ b/gamgee/base_quals.cpp
@@ -1,0 +1,87 @@
+#include "base_quals.h"
+#include "hts_memory.h"
+
+#include <string>
+#include <stdexcept>
+
+using namespace std;
+
+namespace gamgee {
+
+  /**
+   * @brief creates a BaseQuals object that points to htslib memory already allocated
+   *
+   * @note the resulting BaseQuals object shares ownership of the pre-allocated memory via
+   *       shared_ptr reference counting
+   */
+  BaseQuals::BaseQuals(const shared_ptr<bam1_t>& sam_record) :
+    m_sam_record { sam_record },
+    m_quals { bam_get_qual(sam_record.get()) },
+    m_num_quals { uint32_t((sam_record.get())->core.l_qseq) }
+  {}
+
+  /**
+   * @brief creates a deep copy of a BaseQuals object
+   *
+   * @note the copy will have exclusive ownership over the newly-allocated htslib memory
+   */
+  BaseQuals::BaseQuals(const BaseQuals& other) :
+    m_sam_record { make_shared_bam(bam_deep_copy(other.m_sam_record.get())) },
+    m_quals { bam_get_qual(m_sam_record.get()) },
+    m_num_quals { other.m_num_quals }
+  {}
+
+  /**
+   * @brief moves a BaseQuals object, transferring ownership of the underlying htslib memory
+   */
+  BaseQuals::BaseQuals(BaseQuals&& other) :
+    m_sam_record { move(other.m_sam_record) },
+    m_quals { other.m_quals },
+    m_num_quals { other.m_num_quals }
+  {
+    other.m_quals = nullptr;
+  }
+
+  /**
+   * @brief creates a deep copy of a BaseQuals object
+   *
+   * @note the copy will have exclusive ownership over the newly-allocated htslib memory
+   */
+  BaseQuals& BaseQuals::operator=(const BaseQuals& other) {
+    if ( &other != this ) {
+      // shared_ptr assignment will take care of deallocating old sam record if necessary
+      m_sam_record = make_shared_bam(bam_deep_copy(other.m_sam_record.get()));
+      m_quals = bam_get_qual(m_sam_record.get());
+      m_num_quals = other.m_num_quals;
+    }
+
+    return *this;
+  }
+
+  /**
+   * @brief moves a BaseQuals object, transferring ownership of the underlying htslib memory
+   */
+  BaseQuals& BaseQuals::operator=(BaseQuals&& other) {
+    if ( &other != this ) {
+      // shared_ptr assignment will take care of deallocating old sam record if necessary
+      m_sam_record = move(other.m_sam_record);
+      m_quals = other.m_quals;
+      other.m_quals = nullptr;
+      m_num_quals = other.m_num_quals;
+    }
+
+    return *this;
+  }
+
+  /**
+   * @brief access an individual base quality by index
+   *
+   * @return base quality at the specified index as an unsigned byte
+   */
+  uint8_t BaseQuals::operator[](const uint32_t index) const {
+    if ( index >= m_num_quals )
+      throw out_of_range(string("Index ") + to_string(index) + " out of range in BaseQuals::operator[]");
+
+    return m_quals[index];
+  }
+}

--- a/gamgee/base_quals.h
+++ b/gamgee/base_quals.h
@@ -1,0 +1,37 @@
+#ifndef __gamgee__base_quals__
+#define __gamgee__base_quals__
+
+#include "htslib/sam.h"
+
+#include <memory>
+
+namespace gamgee {
+
+class BaseQuals {
+public:
+  explicit BaseQuals(const std::shared_ptr<bam1_t>& sam_record);
+  BaseQuals(const BaseQuals& other);
+  BaseQuals(BaseQuals&& other);
+  BaseQuals& operator=(const BaseQuals& other);
+  BaseQuals& operator=(BaseQuals&& other);
+
+  // Default destruction is sufficient, since our shared_ptr will handle deallocation
+  ~BaseQuals() = default;
+
+  uint8_t operator[](const uint32_t index) const;
+  uint32_t size() const { return m_num_quals; }
+
+private:
+  // Sam record containing our base qualities, potentially co-owned by multiple other objects
+  std::shared_ptr<bam1_t> m_sam_record;
+
+  // Pointer to the start of the base qualities in m_sam_record, cached for efficiency
+  uint8_t* m_quals;
+
+  // Number of quality scores in our sam record
+  uint32_t m_num_quals;
+};
+
+}
+
+#endif /* __gamgee__base_quals__ */

--- a/gamgee/cigar.cpp
+++ b/gamgee/cigar.cpp
@@ -1,0 +1,105 @@
+#include "cigar.h"
+#include "hts_memory.h"
+
+#include <string>
+#include <sstream>
+#include <stdexcept>
+
+using namespace std;
+
+namespace gamgee {
+
+  /**
+   * @brief creates a Cigar object that points to htslib memory already allocated
+   *
+   * @note the resulting Cigar object shares ownership of the pre-allocated memory via
+   *       shared_ptr reference counting
+   */
+  Cigar::Cigar(const shared_ptr<bam1_t>& sam_record) :
+    m_sam_record { sam_record },
+    m_cigar { bam_get_cigar(sam_record.get()) },
+    m_num_cigar_elements { (sam_record.get())->core.n_cigar }
+  {}
+
+  /**
+   * @brief creates a deep copy of a Cigar object
+   *
+   * @note the copy will have exclusive ownership over the newly-allocated htslib memory
+   */
+  Cigar::Cigar(const Cigar& other) :
+    m_sam_record { make_shared_bam(bam_deep_copy(other.m_sam_record.get())) },
+    m_cigar { bam_get_cigar(m_sam_record.get()) },
+    m_num_cigar_elements { other.m_num_cigar_elements }
+  {}
+
+  /**
+   * @brief moves a Cigar object, transferring ownership of the underlying htslib memory
+   */
+  Cigar::Cigar(Cigar&& other) :
+    m_sam_record { move(other.m_sam_record) },
+    m_cigar { other.m_cigar },
+    m_num_cigar_elements { other.m_num_cigar_elements }
+  {
+    other.m_cigar = nullptr;
+  }
+
+  /**
+   * @brief creates a deep copy of a Cigar object
+   *
+   * @note the copy will have exclusive ownership over the newly-allocated htslib memory
+   */
+  Cigar& Cigar::operator=(const Cigar& other) {
+    if ( &other != this ) {
+      // shared_ptr assignment will take care of deallocating old sam record if necessary
+      m_sam_record = make_shared_bam(bam_deep_copy(other.m_sam_record.get()));
+      m_cigar = bam_get_cigar(m_sam_record.get());
+      m_num_cigar_elements = other.m_num_cigar_elements;
+    }
+
+    return *this;
+  }
+
+  /**
+   * @brief moves a Cigar object, transferring ownership of the underlying htslib memory
+   */
+  Cigar& Cigar::operator=(Cigar&& other) {
+    if ( &other != this ) {
+      m_sam_record = move(other.m_sam_record);
+      m_cigar = other.m_cigar;
+      other.m_cigar = nullptr;
+      m_num_cigar_elements = other.m_num_cigar_elements;
+    }
+
+    return *this;
+  }
+
+  /**
+   * @brief access an individual cigar element by index
+   *
+   * @return cigar element at the specified index as an encoded uint32_t. use cigar_op() and
+   *         cigar_oplen() to unpack the cigar operator and length
+   */
+  uint32_t Cigar::operator[](const uint32_t index) const {
+    if ( index >= m_num_cigar_elements )
+      throw out_of_range(string("Index ") + std::to_string(index) + " out of range in Cigar::operator[]");
+
+    return m_cigar[index];
+  }
+
+  // Lookup table to convert CigarOperator enum values to chars. An unfortunate necessity due
+  // to lack of features in C++ enum "classes"
+  const char Cigar::cigar_ops_as_chars[] = { 'M', 'I', 'D', 'N', 'S', 'H', 'P', '=', 'X', 'B' };
+
+  /**
+   * @brief returns a string representation of this cigar
+   */
+  string Cigar::to_string() const {
+    stringstream stream;
+
+    for ( uint32_t i = 0; i < m_num_cigar_elements; ++i ) {
+      stream << cigar_oplen(m_cigar[i]) << cigar_ops_as_chars[static_cast<int>(cigar_op(m_cigar[i]))];
+    }
+
+    return stream.str();
+  }
+}

--- a/gamgee/cigar.h
+++ b/gamgee/cigar.h
@@ -1,0 +1,58 @@
+#ifndef __gamgee__cigar__
+#define __gamgee__cigar__
+
+#include "htslib/sam.h"
+
+#include <memory>
+#include <string>
+
+namespace gamgee {
+
+// Order of the operators in this enum must match the order in BAM_CIGAR_STR from htslib/sam.h
+enum class CigarOperator { M, I, D, N, S, H, P, EQ, X, B };
+
+class Cigar {
+public:
+  explicit Cigar(const std::shared_ptr<bam1_t>& sam_record);
+  Cigar(const Cigar& other);
+  Cigar(Cigar&& other);
+  Cigar& operator=(const Cigar& other);
+  Cigar& operator=(Cigar&& other);
+
+  // Default destruction is sufficient, since our shared_ptr will handle deallocation
+  ~Cigar() = default;
+
+  uint32_t operator[](const uint32_t index) const;
+  uint32_t size() const { return m_num_cigar_elements; }
+  std::string to_string() const;
+
+  /**
+   * @brief gets the operator of an individual cigar element
+   */
+  inline static CigarOperator cigar_op(const uint32_t cigar_element) {
+    return static_cast<CigarOperator>(bam_cigar_op(cigar_element));
+  }
+
+  /**
+   * @brief gets the length of an individual cigar element
+   */
+  inline static uint32_t cigar_oplen(const uint32_t cigar_element) {
+    return bam_cigar_oplen(cigar_element);
+  }
+
+private:
+  // Sam record containing our cigar, potentially co-owned by multiple other objects
+  std::shared_ptr<bam1_t> m_sam_record;
+
+  // Pointer to the start of the cigar in m_sam_record, cached for efficiency
+  uint32_t* m_cigar;
+
+  // Number of elements in our cigar
+  uint32_t m_num_cigar_elements;
+
+  static const char cigar_ops_as_chars[];
+};
+
+}
+
+#endif /* __gamgee__cigar__ */

--- a/gamgee/hts_memory.cpp
+++ b/gamgee/hts_memory.cpp
@@ -1,0 +1,35 @@
+#include "hts_memory.h"
+
+using namespace std;
+
+namespace gamgee {
+
+  /**
+   * @brief wraps a pre-allocated bam1_t in a shared_ptr with correct deleter
+   */
+  shared_ptr<bam1_t> make_shared_bam(bam1_t* bam_ptr) {
+    return shared_ptr<bam1_t>(bam_ptr, BamDeleter());
+  }
+
+  /**
+   * @brief wraps a pre-allocated bam_hdr_t in a shared_ptr with correct deleter
+   */
+  shared_ptr<bam_hdr_t> make_shared_bam_header(bam_hdr_t* bam_header_ptr) {
+    return shared_ptr<bam_hdr_t>(bam_header_ptr, HeaderDeleter());
+  }
+
+  /**
+   * @brief creates a deep copy of an existing bam1_t
+   */
+  bam1_t* bam_deep_copy(bam1_t* original) {
+    return bam_dup1(original);
+  }
+
+  /**
+   * @brief creates a deep copy of an existing bam_hdr_t
+   */
+  bam_hdr_t* bam_header_deep_copy(bam_hdr_t* original) {
+    return bam_hdr_dup(original);
+  }
+
+}

--- a/gamgee/hts_memory.h
+++ b/gamgee/hts_memory.h
@@ -8,7 +8,6 @@
  */
 namespace gamgee {
 
-
 /** 
  * @brief a functor object to delete a bam1_t pointer 
  * 
@@ -24,6 +23,12 @@ struct BamDeleter {
 struct HeaderDeleter {
   void operator()(bam_hdr_t* p) const { bam_hdr_destroy(p); }
 };
+
+std::shared_ptr<bam1_t> make_shared_bam(bam1_t* bam_ptr);
+std::shared_ptr<bam_hdr_t> make_shared_bam_header(bam_hdr_t* bam_header_ptr);
+
+bam1_t* bam_deep_copy(bam1_t* original);
+bam_hdr_t* bam_header_deep_copy(bam_hdr_t* original);
 
 }
 

--- a/gamgee/read_bases.cpp
+++ b/gamgee/read_bases.cpp
@@ -1,0 +1,105 @@
+#include "read_bases.h"
+#include "hts_memory.h"
+
+#include <string>
+#include <sstream>
+#include <stdexcept>
+
+using namespace std;
+
+namespace gamgee {
+
+  /**
+   * @brief creates a ReadBases object that points to htslib memory already allocated
+   *
+   * @note the resulting ReadBases object shares ownership of the pre-allocated memory via
+   *       shared_ptr reference counting
+   */
+  ReadBases::ReadBases(const shared_ptr<bam1_t>& sam_record) :
+    m_sam_record { sam_record },
+    m_bases { bam_get_seq(sam_record.get()) },
+    m_num_bases { uint32_t((sam_record.get())->core.l_qseq) }
+  {}
+
+  /**
+   * @brief creates a deep copy of a ReadBases object
+   *
+   * @note the copy will have exclusive ownership over the newly-allocated htslib memory
+   */
+  ReadBases::ReadBases(const ReadBases& other) :
+    m_sam_record { make_shared_bam(bam_deep_copy(other.m_sam_record.get())) },
+    m_bases { bam_get_seq(m_sam_record.get()) },
+    m_num_bases { other.m_num_bases }
+  {}
+
+  /**
+   * @brief moves a ReadBases object, transferring ownership of the underlying htslib memory
+   */
+  ReadBases::ReadBases(ReadBases&& other) :
+    m_sam_record { move(other.m_sam_record) },
+    m_bases { other.m_bases },
+    m_num_bases { other.m_num_bases }
+  {
+    other.m_bases = nullptr;
+  }
+
+  /**
+   * @brief creates a deep copy of a ReadBases object
+   *
+   * @note the copy will have exclusive ownership over the newly-allocated htslib memory
+   */
+  ReadBases& ReadBases::operator=(const ReadBases& other) {
+    if ( &other != this ) {
+      // shared_ptr assignment will take care of deallocating old sam record if necessary
+      m_sam_record = make_shared_bam(bam_deep_copy(other.m_sam_record.get()));
+      m_bases = bam_get_seq(m_sam_record.get());
+      m_num_bases = other.m_num_bases;
+    }
+
+    return *this;
+  }
+
+  /**
+   * @brief moves a ReadBases object, transferring ownership of the underlying htslib memory
+   */
+  ReadBases& ReadBases::operator=(ReadBases&& other) {
+    if ( &other != this ) {
+      // shared_ptr assignment will take care of deallocating old sam record if necessary
+      m_sam_record = move(other.m_sam_record);
+      m_bases = other.m_bases;
+      other.m_bases = nullptr;
+      m_num_bases = other.m_num_bases;
+    }
+
+    return *this;
+  }
+
+  /**
+   * @brief access an individual base by index
+   *
+   * @return base at the specified index as an enumerated value
+   */
+  Base ReadBases::operator[](const uint32_t index) const {
+    if ( index >= m_num_bases )
+      throw out_of_range(string("Index ") + std::to_string(index) + " out of range in ReadBases::operator[]");
+
+    return static_cast<Base>(bam_seqi(m_bases, index));
+  }
+
+  // Lookup table to convert Base enum values to chars. An unfortunate necessity due
+  // to lack of features in C++ enum "classes"
+  const map<Base, const char*> ReadBases::base_to_string_map = { {Base::A, "A"}, {Base::C, "C"}, {Base::G, "G"}, {Base::T, "T"}, {Base::N, "N"} };
+
+  /**
+   * @brief returns a string representation of the bases in this read
+   */
+  string ReadBases::to_string() const {
+    stringstream ss;
+
+    for ( uint32_t i = 0; i < m_num_bases; i++ ) {
+      ss << base_to_string_map.at((*this)[i]);
+    }
+
+    return ss.str();
+  }
+}

--- a/gamgee/read_bases.h
+++ b/gamgee/read_bases.h
@@ -1,0 +1,45 @@
+#ifndef __gamgee__read_bases__
+#define __gamgee__read_bases__
+
+#include "htslib/sam.h"
+
+#include <memory>
+#include <map>
+
+namespace gamgee {
+
+// Enum values used here correspond to the 4-bit base encodings in htslib so that we can
+// cast directly to Base
+enum class Base { A = 1, C = 2, G = 4, T = 8, N = 15 };
+
+class ReadBases {
+public:
+  explicit ReadBases(const std::shared_ptr<bam1_t>& sam_record);
+  ReadBases(const ReadBases& other);
+  ReadBases(ReadBases&& other);
+  ReadBases& operator=(const ReadBases& other);
+  ReadBases& operator=(ReadBases&& other);
+
+  // Default destruction is sufficient, since our shared_ptr will handle deallocation
+  ~ReadBases() = default;
+
+  Base operator[](const uint32_t index) const;
+  uint32_t size() const { return m_num_bases; };
+  std::string to_string() const;
+
+private:
+  // Sam record containing our bases, potentially co-owned by multiple other objects
+  std::shared_ptr<bam1_t> m_sam_record;
+
+  // Pointer to the start of the bases in m_sam_record, cached for efficiency
+  uint8_t* m_bases;
+
+  // Number of bases in our sam record
+  uint32_t m_num_bases;
+
+  static const std::map<Base, const char*> base_to_string_map;
+};
+
+}
+
+#endif /* __gamgee__read_bases__ */

--- a/gamgee/sam.h
+++ b/gamgee/sam.h
@@ -18,8 +18,12 @@ namespace gamgee {
 class Sam : public SamBody {
  public:
   explicit Sam() = default;
-  Sam(bam1_t* body, const std::shared_ptr<bam_hdr_t>& header) noexcept : SamBody{body}, m_header{header} {}
-  SamHeader header() { return SamHeader{m_header.get()};}
+  explicit Sam(const std::shared_ptr<bam1_t>& body, const std::shared_ptr<bam_hdr_t>& header) noexcept : SamBody{body}, m_header{header} {}
+  SamHeader header() {
+    // TODO: return a reference to a singleton SamHeader object instead of constructing a new one each time,
+    //       since we're already sharing the underlying htslib memory
+    return SamHeader{m_header};
+  }
 
  private:
   std::shared_ptr<bam_hdr_t> m_header;

--- a/gamgee/sam_header.cpp
+++ b/gamgee/sam_header.cpp
@@ -1,33 +1,63 @@
 #include "sam_header.h"
+#include "hts_memory.h"
+
+using namespace std;
 
 namespace gamgee {
 
+  /**
+   * @brief creates an empty SamHeader, allocating new htslib memory
+   */
   SamHeader::SamHeader() :
-    m_header {bam_hdr_init()}
+    m_header { make_shared_bam_header(bam_hdr_init()) }
   {}
 
-  SamHeader::SamHeader(const bam_hdr_t* header) :
-    m_header {bam_hdr_dup(header)}
+  /**
+   * @brief creates a SamHeader object that points to htslib memory already allocated
+   *
+   * @note the resulting SamHeader object shares ownership of the pre-allocated memory via
+   *       shared_ptr reference counting
+   */
+  SamHeader::SamHeader(const shared_ptr<bam_hdr_t>& header) :
+    m_header { header }
   {}
 
+  /**
+   * @brief creates a deep copy of a SamHeader object
+   *
+   * @note the copy will have exclusive ownership over the newly-allocated htslib memory
+   */
   SamHeader::SamHeader(const SamHeader& other) :
-    m_header {bam_hdr_dup(other.m_header)}
+    m_header { make_shared_bam_header(bam_header_deep_copy(other.m_header.get())) }
   {}
 
+  /**
+   * @brief moves a SamHeader object, transferring ownership of the underlying htslib memory
+   */
   SamHeader::SamHeader(SamHeader&& other) :
-    m_header {other.m_header}
-  {
-    other.m_header = nullptr;
+    m_header { move(other.m_header) }
+  {}
+
+  /**
+   * @brief creates a deep copy of a SamHeader object
+   *
+   * @note the copy will have exclusive ownership over the newly-allocated htslib memory
+   */
+  SamHeader& SamHeader::operator=(const SamHeader& other) {
+    if ( &other != this ) {
+      // shared_ptr assignment will take care of deallocating old sam header if necessary
+      m_header = make_shared_bam_header(bam_header_deep_copy(other.m_header.get()));
+    }
+
+    return *this;
   }
 
-  SamHeader::~SamHeader() {
-    bam_hdr_destroy(m_header);
-  }
+  SamHeader& SamHeader::operator=(SamHeader&& other) {
+    if ( &other != this ) {
+      // shared_ptr assignment will take care of deallocating old sam header if necessary
+      m_header = move(other.m_header);
+    }
 
-  SamHeader& SamHeader::operator=(const SamHeader other) {
-    bam_hdr_t* tmp = m_header;
-    m_header = bam_hdr_dup(other.m_header);
-    bam_hdr_destroy(tmp);
     return *this;
   }
 

--- a/gamgee/sam_header.h
+++ b/gamgee/sam_header.h
@@ -3,20 +3,24 @@
 
 #include "htslib/sam.h"
 
+#include <memory>
+
 namespace gamgee {
 
 class SamHeader {
  public:
   explicit SamHeader();
-  // explicit SamHeader(const Sam& record);
-  SamHeader(const bam_hdr_t* header);
+  SamHeader(const std::shared_ptr<bam_hdr_t>& header);
   SamHeader(const SamHeader& other);
   SamHeader(SamHeader&& other);
-  SamHeader& operator=(const SamHeader other);
-  ~SamHeader();
+  SamHeader& operator=(const SamHeader& other);
+  SamHeader& operator=(SamHeader&& other);
+
+  // Default destruction is sufficient, since our shared_ptr will handle deallocation
+  ~SamHeader() = default;
 
  private:
-  bam_hdr_t* m_header;
+  std::shared_ptr<bam_hdr_t> m_header;
 
   friend class SamWriter;
 };

--- a/gamgee/sam_iterator.h
+++ b/gamgee/sam_iterator.h
@@ -66,10 +66,10 @@ class SamIterator {
   private:
     samFile * m_sam_file_ptr;                    ///< pointer to the sam file
     std::shared_ptr<bam_hdr_t> m_sam_header_ptr; ///< pointer to the sam header
-    bam1_t * m_sam_record_ptr;                   ///< pointer to the internal structure of the sam record. Useful to only allocate it once.
+    std::shared_ptr<bam1_t> m_sam_record_ptr;    ///< pointer to the internal structure of the sam record. Useful to only allocate it once.
     Sam m_sam_record;                            ///< temporary record to hold between fetch (operator++) and serve (operator*)
 
-    Sam fetch_next_record();                     ///< makes a new (through copy) Sam object that the user is free to use/keep without having to worry about memory management
+    Sam fetch_next_record();                     ///< fetches next Sam record into existing htslib memory without making a copy
 };
 
 }  // end namespace gamgee

--- a/gamgee/sam_pair_iterator.h
+++ b/gamgee/sam_pair_iterator.h
@@ -67,19 +67,19 @@ class SamPairIterator {
     ~SamPairIterator();
     
   private:
-    using SamPtrQueue = std::queue<std::unique_ptr<bam1_t, BamDeleter>>;
+    using SamPtrQueue = std::queue<std::shared_ptr<bam1_t>>;
 
     SamPtrQueue m_supp_alignments;                     ///< queue to hold the supplementary alignments temporarily while processing the pairs
     samFile * m_sam_file_ptr;                          ///< pointer to the sam file
     const std::shared_ptr<bam_hdr_t> m_sam_header_ptr; ///< pointer to the sam header
-    bam1_t * m_sam_record_ptr1;                        ///< pointer to the internal structure of the sam record. Useful to only allocate it once.
-    bam1_t * m_sam_record_ptr2;                        ///< pointer to the internal structure of the sam record. Useful to only allocate it once.
+    std::shared_ptr<bam1_t> m_sam_record_ptr1;         ///< pointer to the internal structure of the sam record. Useful to only allocate it once.
+    std::shared_ptr<bam1_t> m_sam_record_ptr2;         ///< pointer to the internal structure of the sam record. Useful to only allocate it once.
     std::pair<Sam,Sam> m_sam_records;                  ///< temporary record to hold between fetch (operator++) and serve (operator*)
 
     std::pair<Sam,Sam> fetch_next_pair();              ///< makes a new (through copy) pair of Sam objects that the user is free to use/keep without having to worry about memory management
-    bool read_sam(bam1_t* record_ptr);                 ///< reads a sam record and checks for the end-of-file invalidating the file and header pointers if necessary
-    Sam make_sam(bam1_t* record_ptr);                  ///< creates a sam record from the internal data
-    Sam next_primary_alignment(bam1_t* record_ptr);
+    bool read_sam(std::shared_ptr<bam1_t>& record_ptr);                 ///< reads a sam record and checks for the end-of-file invalidating the file and header pointers if necessary
+    Sam make_sam(std::shared_ptr<bam1_t>& record_ptr);                  ///< creates a sam record from the internal data
+    Sam next_primary_alignment(std::shared_ptr<bam1_t>& record_ptr);
     std::pair<Sam,Sam> next_supplementary_alignment();
 };
 

--- a/gamgee/sam_reader.h
+++ b/gamgee/sam_reader.h
@@ -52,7 +52,7 @@ class SamReader {
      */
     SamReader(const std::string& filename) :
       m_sam_file_ptr {sam_open(filename.empty() ? "-" : filename.c_str(), "r")},
-      m_sam_header_ptr {sam_hdr_read(m_sam_file_ptr), HeaderDeleter()}
+      m_sam_header_ptr { make_shared_bam_header(sam_hdr_read(m_sam_file_ptr)) }
     {}
 
     SamReader(SamReader&& other) :
@@ -91,7 +91,7 @@ class SamReader {
       return ITERATOR{};
     }
 
-    inline SamHeader header() { return SamHeader{m_sam_header_ptr.get()}; }
+    inline SamHeader header() { return SamHeader{m_sam_header_ptr}; }
 
   private:
     samFile* m_sam_file_ptr;                           ///< pointer to the internal file structure of the sam/bam/cram file

--- a/gamgee/sam_writer.cpp
+++ b/gamgee/sam_writer.cpp
@@ -24,7 +24,7 @@ void SamWriter::add_header(const SamHeader& header) {
 }
 
 void SamWriter::add_record(const SamBody& body) { 
-  sam_write1(m_out_file, m_header.m_header, body.m_body); 
+  sam_write1(m_out_file, m_header.m_header.get(), body.m_body.get());
 }
 
 htsFile* SamWriter::open_file(const std::string& output_fname, const std::string& mode) {
@@ -32,7 +32,7 @@ htsFile* SamWriter::open_file(const std::string& output_fname, const std::string
 }
 
 void SamWriter::write_header() const {
-  sam_hdr_write(m_out_file, m_header.m_header); 
+  sam_hdr_write(m_out_file, m_header.m_header.get());
 }
 
 

--- a/test/sam_body_test.cpp
+++ b/test/sam_body_test.cpp
@@ -1,13 +1,61 @@
 #include <boost/test/unit_test.hpp>
+#include <vector>
 #include "sam_body.h"
 #include "sam_reader.h"
 
 using namespace std;
 using namespace gamgee;
 
-BOOST_AUTO_TEST_CASE( sam_body_simple_members ) {
+
+BOOST_AUTO_TEST_CASE( sam_body_simple_members_by_reference ) {
   const auto chr = 5u;
   const auto aln = 1000u;
+  const auto expected_cigar = "76M";
+  const auto expected_cigar_size = 1;
+  const auto expected_cigar_element_length = 76;
+  const auto expected_cigar_element_operator = CigarOperator::M;
+  const auto expected_bases = "ACCCTAACCCTAACCCTAACCCTAACCATAACCCTAAGACTAACCCTAAACCTAACCCTCATAATCGAAATACAAC";
+  const vector<uint8_t> expected_quals = {33, 33, 33, 33, 34, 31, 34, 30, 32, 32, 33, 34, 33, 33, 27, 21, 18, 29, 28, 33, 31, 29, 10, 33, 24, 12, 24, 10, 8, 17, 33, 23, 11, 10, 31, 18, 17, 22, 33, 20, 32, 29, 24, 15, 7, 7, 29, 12, 10, 6, 6, 18, 30, 7, 14, 6, 6, 6, 32, 8, 7, 6, 6, 16, 24, 7, 6, 22, 13, 11, 9, 9, 4, 8, 18, 25};
+
+  for (auto& record : SingleSamReader {"testdata/test_simple.bam"}) {  // should be replaced by mock sam_body
+    record.set_chromosome(chr);
+    BOOST_CHECK_EQUAL(record.chromosome(), chr);
+    record.set_alignment_start(aln);
+    BOOST_CHECK_EQUAL(record.alignment_start(), aln);
+    record.set_mate_chromosome(chr);
+    BOOST_CHECK_EQUAL(record.mate_chromosome(), chr);
+    record.set_mate_alignment_start(aln);
+    BOOST_CHECK_EQUAL(record.mate_alignment_start(), aln);
+
+    // TODO: more comprehensive tests for variable-length data fields once setters are in place
+    const auto actual_cigar = record.cigar();
+    BOOST_CHECK_EQUAL(actual_cigar.to_string(), expected_cigar);
+    BOOST_CHECK_EQUAL(actual_cigar.size(), expected_cigar_size);
+    BOOST_CHECK_EQUAL(static_cast<int>(Cigar::cigar_op(actual_cigar[0])), static_cast<int>(expected_cigar_element_operator));
+    BOOST_CHECK_EQUAL(Cigar::cigar_oplen(actual_cigar[0]), expected_cigar_element_length);
+
+    BOOST_CHECK_EQUAL(record.bases().to_string(), expected_bases);
+
+    const auto actual_quals = record.base_quals();
+    BOOST_CHECK_EQUAL(actual_quals.size(), expected_quals.size());
+    for ( auto i = 0u; i < actual_quals.size(); ++i ) {
+      BOOST_CHECK_EQUAL(actual_quals[i], expected_quals[i]);
+    }
+
+    break;
+  }
+}
+
+BOOST_AUTO_TEST_CASE( sam_body_simple_members_by_copy ) {
+  const auto chr = 5u;
+  const auto aln = 1000u;
+  const auto expected_cigar = "76M";
+  const auto expected_cigar_size = 1;
+  const auto expected_cigar_element_length = 76;
+  const auto expected_cigar_element_operator = CigarOperator::M;
+  const auto expected_bases = "ACCCTAACCCTAACCCTAACCCTAACCATAACCCTAAGACTAACCCTAAACCTAACCCTCATAATCGAAATACAAC";
+  const vector<uint8_t> expected_quals = {33, 33, 33, 33, 34, 31, 34, 30, 32, 32, 33, 34, 33, 33, 27, 21, 18, 29, 28, 33, 31, 29, 10, 33, 24, 12, 24, 10, 8, 17, 33, 23, 11, 10, 31, 18, 17, 22, 33, 20, 32, 29, 24, 15, 7, 7, 29, 12, 10, 6, 6, 18, 30, 7, 14, 6, 6, 6, 32, 8, 7, 6, 6, 16, 24, 7, 6, 22, 13, 11, 9, 9, 4, 8, 18, 25};
+
   for (auto record : SingleSamReader {"testdata/test_simple.bam"}) {  // should be replaced by mock sam_body
     record.set_chromosome(chr);
     BOOST_CHECK_EQUAL(record.chromosome(), chr);
@@ -17,6 +65,22 @@ BOOST_AUTO_TEST_CASE( sam_body_simple_members ) {
     BOOST_CHECK_EQUAL(record.mate_chromosome(), chr);
     record.set_mate_alignment_start(aln);
     BOOST_CHECK_EQUAL(record.mate_alignment_start(), aln);
+
+    // TODO: more comprehensive tests for variable-length data fields once setters are in place
+    const auto actual_cigar = record.cigar();
+    BOOST_CHECK_EQUAL(actual_cigar.to_string(), expected_cigar);
+    BOOST_CHECK_EQUAL(actual_cigar.size(), expected_cigar_size);
+    BOOST_CHECK_EQUAL(static_cast<int>(Cigar::cigar_op(actual_cigar[0])), static_cast<int>(expected_cigar_element_operator));
+    BOOST_CHECK_EQUAL(Cigar::cigar_oplen(actual_cigar[0]), expected_cigar_element_length);
+
+    BOOST_CHECK_EQUAL(record.bases().to_string(), expected_bases);
+
+    const auto actual_quals = record.base_quals();
+    BOOST_CHECK_EQUAL(actual_quals.size(), expected_quals.size());
+    for ( auto i = 0u; i < actual_quals.size(); ++i ) {
+      BOOST_CHECK_EQUAL(actual_quals[i], expected_quals[i]);
+    }
+
     break;
   }
 }


### PR DESCRIPTION
-Added classes and enums to provide convenient access to cigar, base, and
 base qualities

-Implemented shared memory model with reference-counted pointers.
 htslib memory is shared between a SamBody and the classes that
 encapsulate its variable-length data unless the user performs a deep
 copy via the usual C++ copy semantics.

-Removed make_internal_copy() and associated functions from the
 sam_body API. Deep copies are now done exclusively via copy
 construction/assignment.

-Refactored iterators/readers to adjust to the new memory model.

-Refactored sam_header and sam classes to avoid allocating a new
 header on every header access.

-Basic tests

TODOs:

-Setter methods for the variable-length fields (will require htslib
 changes).

-Auxiliary data support

-Better tests (after setters are implemented)
