### PR TITLE
SamBuilder, in-place setters, partial Sam tag support

### DIFF
--- a/gamgee/base_quals.cpp
+++ b/gamgee/base_quals.cpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <stdexcept>
+#include <sstream>
 
 using namespace std;
 
@@ -76,10 +77,57 @@ BaseQuals& BaseQuals::operator=(BaseQuals&& other) noexcept {
   */
 uint8_t BaseQuals::operator[](const uint32_t index) const {
   if ( index >= m_num_quals )
-    throw out_of_range(string("Index ") + to_string(index) + " out of range in BaseQuals::operator[]");
+    throw out_of_range(string("Index ") + std::to_string(index) + " out of range in BaseQuals::operator[]");
 
   return m_quals[index];
 }
 
+/**
+ * @brief access and/or modify an individual base quality by index
+ *
+ * @return base quality at the specified index as an unsigned byte
+ */
+uint8_t& BaseQuals::operator[](const uint32_t index) {
+  if ( index >= m_num_quals )
+    throw out_of_range(string("Index ") + std::to_string(index) + " out of range in BaseQuals::operator[]");
+
+  return m_quals[index];
+}
+
+/**
+ * @brief check whether this object contains the same base qualities as another BaseQuals object
+ */
+bool BaseQuals::operator==(const BaseQuals& other) const {
+  if ( m_num_quals != other.m_num_quals )
+    return false;
+
+  for ( auto i = 0u; i < m_num_quals; ++i ) {
+    if ( m_quals[i] != other.m_quals[i] )
+      return false;
+  }
+
+  return true;
+}
+
+/**
+ * @brief check whether this object does not contain the same base qualities as another BaseQuals object
+ */
+bool BaseQuals::operator!=(const BaseQuals& other) const {
+  return !(*this == other);
+}
+
+/**
+ * @brief produce a string representation of the base qualities in this object
+ */
+std::string BaseQuals::to_string() const {
+  stringstream stream;
+
+  for ( auto i = 0; i < m_num_quals; ++i ) {
+    stream << int(m_quals[i]);
+    if ( i < m_num_quals - 1 )
+      stream << " ";
+  }
+  return stream.str();
+}
 
 } // end of namespace gamgee

--- a/gamgee/base_quals.h
+++ b/gamgee/base_quals.h
@@ -19,13 +19,19 @@ class BaseQuals {
   BaseQuals& operator=(BaseQuals&& other) noexcept;
   ~BaseQuals() = default; ///< Default destruction is sufficient, since our shared_ptr will handle deallocation
 
-  uint8_t operator[](const uint32_t index) const; ///< use freely as you would an array. @note currently implemented as read only
+  uint8_t operator[](const uint32_t index) const; ///< use freely as you would an array.
+  uint8_t& operator[](const uint32_t index);      ///< use freely as you would an array
   uint32_t size() const { return m_num_quals; }   ///< number of base qualities in the container
+  bool operator==(const BaseQuals& other) const;  ///< check for equality with another BaseQuals object
+  bool operator!=(const BaseQuals& other) const;  ///< check for inequality with another BaseQuals object
+  std::string to_string() const;                  ///< produce a string representation of the base qualities in this object
 
  private:
   std::shared_ptr<bam1_t> m_sam_record; ///< sam record containing our base qualities, potentially co-owned by multiple other objects
   uint8_t* m_quals;                     ///< Pointer to the start of the base qualities in m_sam_record, cached for efficiency
   uint32_t m_num_quals;                 ///< Number of quality scores in our sam record
+
+  friend class SamBuilder; ///< builder needs access to the internals in order to build efficiently
 };
 
 }

--- a/gamgee/cigar.cpp
+++ b/gamgee/cigar.cpp
@@ -81,11 +81,40 @@ Cigar& Cigar::operator=(Cigar&& other) noexcept {
   * @return cigar element at the specified index as an encoded uint32_t. use cigar_op() and
   *         cigar_oplen() to unpack the cigar operator and length
   */
-uint32_t Cigar::operator[](const uint32_t index) const {
+CigarElement Cigar::operator[](const uint32_t index) const {
   if ( index >= m_num_cigar_elements )
     throw out_of_range(string("Index ") + std::to_string(index) + " out of range in Cigar::operator[]");
   return m_cigar[index];
 }
+
+/**
+  * @brief access and/or modify an individual cigar element by index
+  *
+  * @return cigar element at the specified index as an encoded uint32_t. use cigar_op() and
+  *         cigar_oplen() to unpack the cigar operator and length
+  */
+CigarElement& Cigar::operator[](const uint32_t index) {
+  if ( index >= m_num_cigar_elements )
+    throw out_of_range(string("Index ") + std::to_string(index) + " out of range in Cigar::operator[]");
+  return m_cigar[index];
+}
+
+bool Cigar::operator==(const Cigar& other) const {
+  if ( m_num_cigar_elements != other.m_num_cigar_elements )
+    return false;
+
+  for ( auto i = 0u; i < m_num_cigar_elements; ++i ) {
+    if ( m_cigar[i] != other.m_cigar[i] )
+      return false;
+  }
+
+  return true;
+}
+
+bool Cigar::operator!=(const Cigar& other) const {
+  return !(*this == other);
+}
+
 
 /**
   * @brief returns a string representation of this cigar

--- a/gamgee/read_bases.cpp
+++ b/gamgee/read_bases.cpp
@@ -83,6 +83,42 @@ namespace gamgee {
   }
 
   /**
+   * @brief set an individual base at the given index to the specified value
+   *
+   * @note there's no way to implement this using non-const operator[], since
+   *       we can't return a reference to a half-byte in memory
+   */
+  void ReadBases::set_base(const uint32_t index, const Base base) {
+    if ( index >= m_num_bases )
+      throw out_of_range(string("Index ") + std::to_string(index) + " out of range in ReadBases::set_base");
+
+    m_bases[index >> 1] &= ~(0xF << ((~index & 1) << 2));   ///< zero out previous 4-bit base encoding
+    m_bases[index >> 1] |= static_cast<uint8_t>(base) << ((~index & 1) << 2);  ///< insert new 4-bit base encoding
+  }
+
+  /**
+   * @brief check whether this object contains the same bases as another ReadBases object
+   */
+  bool ReadBases::operator==(const ReadBases& other) const {
+    if ( m_num_bases != other.m_num_bases )
+      return false;
+
+    for ( auto i = 0u; i < m_num_bases; ++i ) {
+      if ( (*this)[i] != other[i] )
+        return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * @brief check whether this object does not contain the same bases as another ReadBases object
+   */
+  bool ReadBases::operator!=(const ReadBases& other) const {
+    return !(*this == other);
+  }
+
+  /**
    * @brief returns a string representation of the bases in this read
    */
   string ReadBases::to_string() const {

--- a/gamgee/read_bases.h
+++ b/gamgee/read_bases.h
@@ -33,8 +33,11 @@ public:
   ~ReadBases() = default; ///< default destruction is sufficient, since our shared_ptr will handle deallocation
 
   Base operator[](const uint32_t index) const;   ///< use freely as you would an array. @note currently implemented as read only
+  void set_base(const uint32_t index, const Base base);  ///< modify a base at a specific index
   uint32_t size() const { return m_num_bases; }; ///< number of base qualities in the container
-  std::string to_string() const;
+  bool operator==(const ReadBases& other) const; ///< check for equality with another ReadBases object
+  bool operator!=(const ReadBases& other) const; ///< check for inequality with another ReadBases object
+  std::string to_string() const;  ///< produce a string representation of the bases in this object
 
 private:
   std::shared_ptr<bam1_t> m_sam_record; ///< sam record containing our bases, potentially co-owned by multiple other objects
@@ -42,6 +45,8 @@ private:
   uint32_t m_num_bases;                 ///< number of bases in our sam record
 
   static const std::map<Base, const char*> base_to_string_map; ///< @brief simple lookup table to convert Base enum values to chars. 
+
+  friend class SamBuilder; ///< builder needs access to the internals in order to build efficiently
 };
 
 }

--- a/gamgee/sam.cpp
+++ b/gamgee/sam.cpp
@@ -111,5 +111,67 @@ uint32_t Sam::unclipped_stop() const {
   return pos;
 }
 
+/**
+ * @brief retrieve an integer-valued tag by name
+ *
+ * @note returns a SamTag with is_present() == false if the read has no tag by this name
+ */
+SamTag<int32_t> Sam::integer_tag(const std::string& tag_name) const {
+  const auto aux_ptr = bam_aux_get(m_body.get(), tag_name.c_str());
+  return aux_ptr == nullptr ? SamTag<int32_t>(tag_name, 0, false) :
+                              SamTag<int32_t>(tag_name, bam_aux2i(aux_ptr));
+
+  // TODO: htslib bam_aux2i() returns 0 if the tag is not of integer type,
+  //       but 0 is a valid value for a correctly-typed tag. This should be patched.
+}
+
+/**
+ * @brief retrieve a double/float-valued tag by name
+ *
+ * @note returns a SamTag with is_present() == false if the read has no tag by this name
+ */
+SamTag<double> Sam::double_tag(const std::string& tag_name) const {
+  const auto aux_ptr = bam_aux_get(m_body.get(), tag_name.c_str());
+  return aux_ptr == nullptr ? SamTag<double>(tag_name, 0.0, false) :
+                              SamTag<double>(tag_name, bam_aux2f(aux_ptr));
+
+  // TODO: htslib bam_aux2f() returns 0.0 if the tag is not of double/float type,
+  //       but 0.0 is a valid value for a correctly-typed tag. This should be patched.
+}
+
+/**
+ * @brief retrieve a char-valued tag by name
+ *
+ * @note returns a SamTag with is_present() == false if the read has no tag by this name
+ */
+SamTag<char> Sam::char_tag(const std::string& tag_name) const {
+  const auto aux_ptr = bam_aux_get(m_body.get(), tag_name.c_str());
+  if ( aux_ptr == nullptr )  // tag doesn't exist
+    return SamTag<char>(tag_name, '\0', false);
+
+  const auto char_val = bam_aux2A(aux_ptr);
+  if ( char_val == '\0' )    // tag not of char type
+    return SamTag<char>(tag_name, '\0', false);
+
+  return SamTag<char>(tag_name, char_val);
+}
+
+/**
+ * @brief retrieve a string-valued tag by name
+ *
+ * @note returns a SamTag with is_present() == false if the read has no tag by this name
+ */
+SamTag<std::string> Sam::string_tag(const std::string& tag_name) const {
+  const auto aux_ptr = bam_aux_get(m_body.get(), tag_name.c_str());
+  if ( aux_ptr == nullptr )  // tag doesn't exist
+    return SamTag<string>(tag_name, "", false);
+
+  const auto str_ptr = bam_aux2Z(aux_ptr);
+  if ( str_ptr == nullptr )  // tag not of string type
+    return SamTag<string>(tag_name, "", false);
+
+  return SamTag<string>(tag_name, string{str_ptr});
+}
+
 }
 

--- a/gamgee/sam_builder.cpp
+++ b/gamgee/sam_builder.cpp
@@ -1,0 +1,393 @@
+#include "sam_builder.h"
+#include "utils/hts_memory.h"
+
+#include <algorithm>
+#include <sstream>
+#include <stdexcept>
+#include <stdlib.h>
+
+using namespace std;
+
+namespace gamgee {
+
+/**
+ * @brief Table used to parse chars representing cigar operations into their htslib encodings
+ *
+ * @note: This table should eventually be moved to htslib. Currently htslib dynamically allocates
+ *        and fills the equivalent of this table on-demand, which makes little sense.
+ */
+const int8_t SamBuilder::cigar_op_parse_table[] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,7,-1,-1,-1,-1,9,-1,2,-1,-1,-1,5,1,-1,-1,-1,0,3,-1,6,-1,-1,4,-1,-1,-1,-1,8,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+
+/**
+ * @brief create a Sam from scratch, starting only with a header
+ *
+ * @note users of this constructor will need to fill in sufficient parts of the read
+ *       to produce a valid read
+ */
+SamBuilder::SamBuilder(const SamHeader& header, const bool validate_on_build) :
+  m_core_read { header.m_header, utils::make_shared_sam(bam_init1()) },
+  m_name {},
+  m_cigar {},
+  m_bases {},
+  m_base_quals {},
+  m_tags {},
+  m_validate_on_build { validate_on_build }
+{}
+
+/**
+ * @brief create a Sam starting with an existing read and its header
+ *
+ * @note the data in the existing read is copied into the builder so that future changes
+ *       to the read will not affect the builder
+ */
+SamBuilder::SamBuilder(const Sam& starting_read, const bool validate_on_build) :
+  m_core_read { starting_read.m_header, utils::make_shared_sam(utils::sam_shallow_copy(starting_read.m_body.get())) },
+  m_name { bam_get_qname(starting_read.m_body.get()), starting_read.m_body.get()->core.l_qname, 1 },
+  m_cigar { bam_get_cigar(starting_read.m_body.get()), uint32_t(starting_read.m_body.get()->core.n_cigar << 2), uint32_t(starting_read.m_body.get()->core.n_cigar) },
+  m_bases { bam_get_seq(starting_read.m_body.get()), uint32_t((starting_read.m_body.get()->core.l_qseq + 1) >> 1), uint32_t(starting_read.m_body.get()->core.l_qseq) },
+  m_base_quals { bam_get_qual(starting_read.m_body.get()), uint32_t(starting_read.m_body.get()->core.l_qseq), uint32_t(starting_read.m_body.get()->core.l_qseq) },
+  m_tags { bam_get_aux(starting_read.m_body.get()), uint32_t(bam_get_l_aux(starting_read.m_body.get())), 0 },
+  m_validate_on_build { validate_on_build }
+{}
+
+/**
+ * @brief create a Sam starting with an existing read, and manually set the header to a custom value
+ *
+ * @note the data in the existing read is copied into the builder so that future changes
+ *       to the read will not affect the builder
+ */
+SamBuilder::SamBuilder(const SamHeader& header, const Sam& starting_read, const bool validate_on_build) :
+  m_core_read { header.m_header, utils::make_shared_sam(utils::sam_shallow_copy(starting_read.m_body.get())) },
+  m_name { bam_get_qname(starting_read.m_body.get()), starting_read.m_body.get()->core.l_qname, 1 },
+  m_cigar { bam_get_cigar(starting_read.m_body.get()), uint32_t(starting_read.m_body.get()->core.n_cigar << 2), uint32_t(starting_read.m_body.get()->core.n_cigar) },
+  m_bases { bam_get_seq(starting_read.m_body.get()), uint32_t((starting_read.m_body.get()->core.l_qseq + 1) >> 1), uint32_t(starting_read.m_body.get()->core.l_qseq) },
+  m_base_quals { bam_get_qual(starting_read.m_body.get()), uint32_t(starting_read.m_body.get()->core.l_qseq), uint32_t(starting_read.m_body.get()->core.l_qseq) },
+  m_tags { bam_get_aux(starting_read.m_body.get()), uint32_t(bam_get_l_aux(starting_read.m_body.get())), 0 },
+  m_validate_on_build { validate_on_build }
+{}
+
+/**
+ * @brief create a builder by move from an existing builder
+ */
+SamBuilder::SamBuilder(SamBuilder&& other) noexcept :
+  m_core_read { move(other.m_core_read) },
+  m_name { move(other.m_name) },
+  m_cigar { move(other.m_cigar) },
+  m_bases { move(other.m_bases) },
+  m_base_quals { move(other.m_base_quals) },
+  m_tags { move(other.m_tags) },
+  m_validate_on_build { other.m_validate_on_build }
+{}
+
+/**
+ * @brief move an existing builder's state into this object
+ */
+SamBuilder& SamBuilder::operator=(SamBuilder&& other) noexcept {
+  if ( &other == this )
+    return *this;
+
+  m_core_read = move(other.m_core_read);
+  m_name = move(other.m_name);
+  m_cigar = move(other.m_cigar);
+  m_bases = move(other.m_bases);
+  m_base_quals = move(other.m_base_quals);
+  m_tags = move(other.m_tags);
+  m_validate_on_build = other.m_validate_on_build;
+  return *this;
+}
+
+/**
+ * @brief set the read's QNAME to the specified value
+ */
+SamBuilder& SamBuilder::set_name(const std::string& new_name) {
+  m_name.update(new_name.c_str(), new_name.length() + 1, 1);  // include a byte for null terminator
+  return *this;
+}
+
+/**
+ * @brief set the read's cigar to the cigar of an existing read
+ *
+ * @note performs a copy of the other read's cigar
+ */
+SamBuilder& SamBuilder::set_cigar(const Cigar& new_cigar) {
+  m_cigar.update(new_cigar.m_cigar, new_cigar.m_num_cigar_elements * sizeof(CigarElement), new_cigar.m_num_cigar_elements);
+  return *this;
+}
+
+/**
+ * @brief set the read's cigar using a vector of CigarElements
+ *
+ * @note CigarElements can be created via Cigar::make_cigar_element()
+ * @note copies the contents of the vector
+ */
+SamBuilder& SamBuilder::set_cigar(const std::vector<CigarElement>& new_cigar) {
+  m_cigar.update(&(new_cigar[0]), new_cigar.size() * sizeof(CigarElement), new_cigar.size());
+  return *this;
+}
+
+/**
+ * @brief set the read's cigar using an initializer_list of CigarElements
+ *
+ * @note CigarElements can be created via Cigar::make_cigar_element()
+ * @note initializer_lists must be passed by value as per Stroustrup p. 497,
+ *       but this is efficient as internally only pointers are copied
+ */
+SamBuilder& SamBuilder::set_cigar(const std::initializer_list<CigarElement> new_cigar) {
+  return set_cigar(vector<CigarElement>{new_cigar});
+}
+
+/**
+ * @brief set the read's cigar using a string representation of a cigar (eg., "3M1I3M")
+ *
+ * @note will throw invalid_argument if there is an error parsing the string
+ * @note this is the least efficient way to set a cigar
+ */
+SamBuilder& SamBuilder::set_cigar(const std::string& new_cigar) {
+  if ( new_cigar.length() == 0 )
+    throw invalid_argument("Empty cigar passed to set_cigar()");
+
+  // Find the number of operators by counting non-digits
+  auto num_cigar_elements = new_cigar.length() - count_if(new_cigar.begin(), new_cigar.end(), ::isdigit);
+  if ( num_cigar_elements == 0 )
+    throw invalid_argument(string("No operators in cigar: ") + new_cigar);
+
+  auto encoded_cigar = unique_ptr<uint8_t[]>{ new uint8_t[num_cigar_elements * sizeof(CigarElement)] };
+  auto encoded_cigar_ptr = (uint32_t*)encoded_cigar.get();
+
+  // cannot use auto here since stringstream is not moveable
+  // (yeah, "almost always auto" actually involves a lot of overhead in the form of "auto x = type{}"
+  // move assignments)
+  stringstream new_cigar_stream{ new_cigar };
+  for ( auto i = 0u; i < num_cigar_elements; ++i ) {
+    unsigned long element_length;
+    unsigned char element_op;
+
+    new_cigar_stream >> element_length;
+    if ( new_cigar_stream.fail() )
+      throw invalid_argument(string("Error parsing cigar string: ") + new_cigar);
+
+    new_cigar_stream >> element_op;
+    if ( new_cigar_stream.fail() || int(element_op) >= 128 )
+      throw invalid_argument(string("Error parsing cigar string: ") + new_cigar);
+
+    auto encoded_op = cigar_op_parse_table[int(element_op)];
+    if ( encoded_op < 0 )
+      throw invalid_argument(string("Unrecognized operator ") + char(element_op) + " in cigar string: " + new_cigar);
+
+    encoded_cigar_ptr[i] = (element_length << BAM_CIGAR_SHIFT) | encoded_op;
+  }
+
+  // move existing encoded cigar we've just created into the field to avoid an extra copy
+  m_cigar.update(move(encoded_cigar), num_cigar_elements * sizeof(CigarElement), num_cigar_elements);
+  return *this;
+}
+
+/**
+ * @brief set the read's bases to the bases of an existing read
+ *
+ * @note copies the other read's bases
+ */
+SamBuilder& SamBuilder::set_bases(const ReadBases& new_bases) {
+  m_bases.update(new_bases.m_bases, (new_bases.m_num_bases + 1) >> 1, new_bases.m_num_bases);
+  return *this;
+}
+
+/**
+ * @brief set the read's bases using a vector of Bases
+ *
+ * @note copies the contents of the vector
+ */
+SamBuilder& SamBuilder::set_bases(const std::vector<Base>& new_bases) {
+  auto encoded_size = (new_bases.size() + 1) >> 1;
+  auto encoded_bases = unique_ptr<uint8_t[]>{ new uint8_t[encoded_size] };
+  auto encoded_base_ptr = encoded_bases.get();
+
+  // 4 bits per base
+  memset(encoded_base_ptr, 0, encoded_size);
+  for ( auto i = 0u; i < new_bases.size(); ++i ) {
+    encoded_base_ptr[i >> 1] |= static_cast<uint8_t>(new_bases[i]) << ((~i & 1) << 2);
+  }
+
+  // move the encoded bases we just created into the field to avoid an extra copy
+  m_bases.update(move(encoded_bases), encoded_size, new_bases.size());
+  return *this;
+}
+
+/**
+ * @brief set the read's bases using an initializer_list of Bases
+ *
+ * @note initializer_lists must be passed by value as per Stroustrup p. 497,
+ *       but this is efficient as internally only pointers are copied
+ */
+SamBuilder& SamBuilder::set_bases(const std::initializer_list<Base> new_bases) {
+  return set_bases(vector<Base>{new_bases});
+}
+
+/**
+ * @brief set the read's bases using a string of base values (eg., "ACGT")
+ *
+ * @note this is the least efficient way to set the bases
+ */
+SamBuilder& SamBuilder::set_bases(const std::string& new_bases) {
+  auto encoded_size = (new_bases.length() + 1) >> 1;
+  auto encoded_bases = unique_ptr<uint8_t[]>{ new uint8_t[encoded_size] };
+  auto encoded_base_ptr = encoded_bases.get();
+
+  // 4 bits per base
+  memset(encoded_base_ptr, 0, encoded_size);
+  for ( auto i = 0u; i < new_bases.length(); ++i ) {
+    encoded_base_ptr[i >> 1] |= seq_nt16_table[int(new_bases[i])] << ((~i & 1) << 2);
+  }
+
+  // move the encoded bases we just created into the field to avoid an extra copy
+  m_bases.update(move(encoded_bases), encoded_size, new_bases.length());
+  return *this;
+}
+
+/**
+ * @brief set the read's base qualities to the base qualities of an existing read
+ *
+ * @note copies the existing read's base qualities
+ */
+SamBuilder& SamBuilder::set_base_quals(const BaseQuals& new_base_quals) {
+  m_base_quals.update(new_base_quals.m_quals, new_base_quals.m_num_quals, new_base_quals.m_num_quals);
+  return *this;
+}
+
+/**
+ * @brief set the read's base qualities using a vector of quality scores
+ *
+ * @note copies the contents of the vector
+ */
+SamBuilder& SamBuilder::set_base_quals(const std::vector<uint8_t>& new_base_quals) {
+  m_base_quals.update(&(new_base_quals[0]), new_base_quals.size(), new_base_quals.size());
+  return *this;
+}
+
+/**
+ * @brief set the read's base qualities using an initializer_list of (uint8_t) quality scores
+ *
+ * @note to use this version, you must explicitly specify that the type of elements in the
+ *       initializer_list is uint8_t (eg., initializer_list<uint8_t>{1, 2, 3})
+ */
+SamBuilder& SamBuilder::set_base_quals(const std::initializer_list<uint8_t> new_base_quals) {
+  return set_base_quals(vector<uint8_t>{new_base_quals});
+}
+
+/**
+ * @brief set the read's base qualities using an initializer_list of (int) quality scores
+ *
+ * @note this version can be used without specifying the type of the elements in
+ *       the initializer_list (eg., set_base_quals({1, 2, 3})), but it is less
+ *       efficient than the other versions since it must perform a range check on
+ *       each score
+ */
+SamBuilder& SamBuilder::set_base_quals(const std::initializer_list<int> new_base_quals) {
+  // Unfortunately, to allow use of initializer lists of quality scores without casting/explicit typing,
+  // we need to provide this version that takes an initializer_list<int> instead of an initializer_list<uint8_t>.
+  // This means that we must range check the values in the initializer list and explicitly cast them.
+  // However, this is acceptable given that this setter is likely to only be called in tests.
+  auto quals_vector = vector<uint8_t>(new_base_quals.size());
+  auto idx = 0;
+  for ( auto qual : new_base_quals ) {
+    if ( qual < 0 || qual > 255 )
+      throw invalid_argument(string{"Base quality "} + std::to_string(qual) + " invalid. Base qualities must be between 0-255");
+
+    quals_vector[idx] = static_cast<uint8_t>(qual);
+    ++idx;
+  }
+  return set_base_quals(quals_vector);
+}
+
+/**
+ * @brief build a Sam record using the current state of the builder
+ *
+ * @note this version of build() can be called repeatedly to build multiple Sam objects with
+ *       small variations
+ */
+Sam SamBuilder::build() const {
+  // Perform validation before building, if requested
+  if ( m_validate_on_build )
+    validate();
+
+  // Allocate memory for a new Sam
+  auto new_sam_body = utils::make_shared_sam(bam_init1());
+  auto sam_body_ptr = new_sam_body.get();
+
+  // Copy core information first, then construct the concatenated data field
+  *(sam_body_ptr) = *(m_core_read.m_body.get());
+  build_data_array(sam_body_ptr);
+
+  // Calculate the bin using the same method as htslib
+  sam_body_ptr->core.bin = hts_reg2bin(sam_body_ptr->core.pos, sam_body_ptr->core.pos + sam_body_ptr->core.l_qseq, 14, 5);
+  // TODO: we don't currently explicitly handle TLEN (core.isize)
+
+  return Sam{ m_core_read.m_header, new_sam_body };
+}
+
+/**
+ * @brief build a Sam record more efficiently by moving the builder's data out to the caller and invalidating the builder's state
+ *
+ * @note this method can be called only once, and the builder should not be used after it's called
+ */
+Sam SamBuilder::one_time_build() {
+  // Perform validation before building, if requested
+  if ( m_validate_on_build )
+    validate();
+
+  // Don't allocate a new Sam -- we'll use the existing memory in m_core_read. We
+  // still need to construct the data field, though.
+  auto sam_body_ptr = m_core_read.m_body.get();
+  build_data_array(sam_body_ptr);
+
+  // Calculate the bin using the same method as htslib
+  sam_body_ptr->core.bin = hts_reg2bin(sam_body_ptr->core.pos, sam_body_ptr->core.pos + sam_body_ptr->core.l_qseq, 14, 5);
+  // TODO: we don't currently explicitly handle TLEN (core.isize)
+
+  // Move m_core_read itself out to the caller, invalidating this builder
+  return move(m_core_read);
+}
+
+/**
+ * @brief performs pre-build validation of the state of the Sam record under construction
+ */
+void SamBuilder::validate() const {
+  // Make sure required data fields have been set
+  if ( m_name.is_empty() || m_cigar.is_empty() || m_bases.is_empty() || m_base_quals.is_empty() )
+    throw logic_error("Missing one or more required data fields (name, cigar, bases, or base qualities)");
+
+  // Make sure the sequence length implied by the cigar matches the actual sequence length
+  if ( bam_cigar2qlen(m_cigar.num_elements(), (const uint32_t*)m_cigar.raw_data_ptr()) != m_bases.num_elements() )
+    throw logic_error("Cigar operations and number of bases do not match");
+
+  // Make sure the number of base qualities matches the number of bases
+  if ( m_base_quals.num_elements() != m_bases.num_elements() )
+    throw logic_error("Number of bases and number of base qualities do not match");
+
+  // TODO: add additional validation of the core (non-data) fields
+}
+
+/**
+ * @brief helper function that constructs the concatenated htslib-encoded data array
+ */
+void SamBuilder::build_data_array(bam1_t* sam) const {
+  const auto data_array_bytes = m_name.num_bytes() + m_cigar.num_bytes() + m_bases.num_bytes() + m_base_quals.num_bytes() + m_tags.num_bytes();
+  // use malloc() instead of new so that htslib can free this memory
+  auto data_array = (uint8_t*)malloc(data_array_bytes);
+  auto data_array_ptr = data_array;
+
+  data_array_ptr = m_name.copy_into(data_array_ptr);
+  data_array_ptr = m_cigar.copy_into(data_array_ptr);
+  data_array_ptr = m_bases.copy_into(data_array_ptr);
+  data_array_ptr = m_base_quals.copy_into(data_array_ptr);
+  data_array_ptr = m_tags.copy_into(data_array_ptr);
+
+  sam->data = data_array;
+  sam->l_data = data_array_bytes;
+  sam->m_data = data_array_bytes;
+  sam->core.l_qname = m_name.num_bytes();
+  sam->core.l_qseq = m_bases.num_elements();
+  sam->core.n_cigar = m_cigar.num_elements();
+}
+
+}

--- a/gamgee/sam_builder.h
+++ b/gamgee/sam_builder.h
@@ -1,0 +1,138 @@
+#ifndef __gamgee__sam_builder__
+#define __gamgee__sam_builder__
+
+#include "sam.h"
+#include "sam_builder_data_field.h"
+
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace gamgee {
+
+/**
+ * @brief class to build Sam objects from existing data or from scratch
+ *
+ * Unlike the setters in the Sam class, which only allow in-place modification of
+ * the data for efficiency reasons, SamBuilder lets you construct a read in arbitrary
+ * ways (including resizing data elements like the number of quality scores and the cigar).
+ *
+ * To use, either start from scratch with only a header:
+ *
+ * auto builder = SamBuilder{header};
+ *
+ * or start with the state in an existing read:
+ *
+ * auto builder = SamBuilder{existing_read};
+ *
+ * Then make the desired modifications and build repeatedly.
+ *
+ * auto read1 = builder.set_cigar("1M1I1M").set_base_quals({1,2,3}).build();
+ * auto read2 = builder.set_name("new_name").set_chromosome(3).build();
+ *
+ * Alternatively, you may use the one_time_build() function if you only need
+ * to ever build one read using a given builder. This is slightly more efficient
+ * than the more general-purpose repeatable build() function.
+ *
+ * You must provide a value for all essential data fields before building if you
+ * build from scratch, unless you disable validation (not recommended).
+ *
+ * Some methods of setting values are more efficient than others. For example,
+ * setting a cigar using a vector is much more efficient than setting it via a string:
+ *
+ * builder.set_cigar(vector<CigarElement>{Cigar::make_cigar_element(3, CigarOperator::M)});
+ *   is faster than:
+ * builder.set_cigar("3M");
+ *
+ * since the string must be parsed and validated.
+ *
+ * The builder always copies the data it's given in the set_* methods, even when it belongs
+ * to another read, for safety reasons. Altering a read after passing some of its data into
+ * a builder will not affect the state of the builder.
+ *
+ * Before building, the builder performs a validation step to ensure that the read it will
+ * create is logically consistent (eg., number of base qualities must match the number of bases).
+ * This validation step can be disabled during construction of the builder, but disabling
+ * validation is dangerous and not recommended.
+ */
+class SamBuilder {
+ public:
+  explicit SamBuilder(const SamHeader& header, const bool validate_on_build = true);                           ///< @brief create a Sam from scratch, starting only with a header
+  explicit SamBuilder(const Sam& starting_read, const bool validate_on_build = true);                          ///< @brief create a Sam starting with an existing read and its header
+  explicit SamBuilder(const SamHeader& header, const Sam& starting_read, const bool validate_on_build = true); ///< @brief create a Sam starting with an existing read, and manually set the header to a custom value
+
+  // SamBuilders are moveable but not copyable, and use default destruction
+  SamBuilder(SamBuilder&& other) noexcept;
+  SamBuilder& operator=(SamBuilder&& other) noexcept;
+  SamBuilder(const SamBuilder& other) = delete;
+  SamBuilder& operator=(const SamBuilder& other) = delete;
+  ~SamBuilder() = default;
+
+  // Setters for data fields
+  SamBuilder& set_name(const std::string& new_name);
+
+  SamBuilder& set_cigar(const Cigar& new_cigar);
+  SamBuilder& set_cigar(const std::vector<CigarElement>& new_cigar);
+  SamBuilder& set_cigar(const std::initializer_list<CigarElement> new_cigar);
+  SamBuilder& set_cigar(const std::string& new_cigar);
+
+  SamBuilder& set_bases(const ReadBases& new_bases);
+  SamBuilder& set_bases(const std::vector<Base>& new_bases);
+  SamBuilder& set_bases(const std::initializer_list<Base> new_bases);
+  SamBuilder& set_bases(const std::string& new_bases);
+
+  SamBuilder& set_base_quals(const BaseQuals& new_base_quals);
+  SamBuilder& set_base_quals(const std::vector<uint8_t>& new_base_quals);
+  SamBuilder& set_base_quals(const std::initializer_list<uint8_t> new_base_quals);
+  SamBuilder& set_base_quals(const std::initializer_list<int> new_base_quals);
+
+  // Setters for core fields: these pass through to the implementations in Sam
+  SamBuilder& set_chromosome(const uint32_t chr)              { m_core_read.set_chromosome(chr); return *this;              } ///< @brief simple setter for the chromosome index. Index is 0-based.
+  SamBuilder& set_alignment_start(const uint32_t start)       { m_core_read.set_alignment_start(start); return *this;       } ///< @brief simple setter for the alignment start. @warning You should use (1-based and inclusive) alignment but internally this is stored 0-based to simplify BAM conversion.
+  SamBuilder& set_mate_chromosome(const uint32_t mchr)        { m_core_read.set_mate_chromosome(mchr); return *this;        } ///< @brief simple setter for the mate's chromosome index. Index is 0-based.
+  SamBuilder& set_mate_alignment_start(const uint32_t mstart) { m_core_read.set_mate_alignment_start(mstart); return *this; } ///< @brief simple setter for the mate's alignment start. @warning You should use (1-based and inclusive) alignment but internally this is stored 0-based to simplify BAM conversion.
+  SamBuilder& set_paired()            { m_core_read.set_paired(); return *this;            }
+  SamBuilder& set_not_paired()        { m_core_read.set_not_paired(); return *this;        }
+  SamBuilder& set_unmapped()          { m_core_read.set_unmapped(); return *this;          }
+  SamBuilder& set_not_unmapped()      { m_core_read.set_not_unmapped(); return *this;      }
+  SamBuilder& set_next_unmapped()     { m_core_read.set_next_unmapped(); return *this;     }
+  SamBuilder& set_not_next_unmapped() { m_core_read.set_not_next_unmapped(); return *this; }
+  SamBuilder& set_reverse()           { m_core_read.set_reverse(); return *this;           }
+  SamBuilder& set_not_reverse()       { m_core_read.set_not_reverse(); return *this;       }
+  SamBuilder& set_next_reverse()      { m_core_read.set_next_reverse(); return *this;      }
+  SamBuilder& set_not_next_reverse()  { m_core_read.set_not_next_reverse(); return *this;  }
+  SamBuilder& set_first()             { m_core_read.set_first(); return *this;             }
+  SamBuilder& set_not_first()         { m_core_read.set_not_first(); return *this;         }
+  SamBuilder& set_last()              { m_core_read.set_last(); return *this;              }
+  SamBuilder& set_not_last()          { m_core_read.set_not_last(); return *this;          }
+  SamBuilder& set_secondary()         { m_core_read.set_secondary(); return *this;         }
+  SamBuilder& set_not_secondary()     { m_core_read.set_not_secondary(); return *this;     }
+  SamBuilder& set_fail()              { m_core_read.set_fail(); return *this;              }
+  SamBuilder& set_not_fail()          { m_core_read.set_not_fail(); return *this;          }
+  SamBuilder& set_duplicate()         { m_core_read.set_duplicate(); return *this;         }
+  SamBuilder& set_not_duplicate()     { m_core_read.set_not_duplicate(); return *this;     }
+  SamBuilder& set_supplementary()     { m_core_read.set_supplementary(); return *this;     }
+  SamBuilder& set_not_supplementary() { m_core_read.set_not_supplementary(); return *this; }
+
+  Sam build() const;    ///< build a Sam (can be called repeatedly)
+  Sam one_time_build(); ///< build a Sam more efficiently by moving the builder's data out of it and invalidating future builds
+
+ private:
+  Sam m_core_read;   ///< Shallow Sam object containing only the core (non-data) parts of the read
+  SamBuilderDataField m_name;       ///< htslib encoded name for eventual inclusion in the data field
+  SamBuilderDataField m_cigar;      ///< htslib encoded cigar for eventual inclusion in the data field
+  SamBuilderDataField m_bases;      ///< htslib encoded bases for eventual inclusion in the data field
+  SamBuilderDataField m_base_quals; ///< htslib encoded base qualities for eventual inclusion in the data field
+  SamBuilderDataField m_tags;       ///< htslib encoded aux data (tags) for eventual inclusion in the data field
+  bool m_validate_on_build;         ///< should we validate the state of the Sam record at build time?
+
+  static const int8_t cigar_op_parse_table[];  ///< @brief Table used to parse chars representing cigar operations into their htslib encodings
+
+  void validate() const;                    ///< @brief performs pre-build validation of the state of the Sam record under construction
+  void build_data_array(bam1_t* sam) const; ///< @brief helper function that constructs the concatenated htslib-encoded data array
+};
+
+}
+
+
+#endif /* __gamgee__sam_builder__ */

--- a/gamgee/sam_builder_data_field.cpp
+++ b/gamgee/sam_builder_data_field.cpp
@@ -1,0 +1,97 @@
+#include "sam_builder_data_field.h"
+
+#include <cstring>
+
+using namespace std;
+
+namespace gamgee {
+
+/**
+ * @brief initialize a SamBuilderDataField to an empty value
+ */
+SamBuilderDataField::SamBuilderDataField() :
+  m_data {},
+  m_num_bytes { 0 },  // Note: default no-arg constructor would NOT zero out the POD members
+  m_num_elements { 0 }
+{}
+
+/**
+ * @brief initialize a SamBuilderDataField by copying data from a raw pointer
+ *
+ * @note takes no ownership of copy_source
+ */
+SamBuilderDataField::SamBuilderDataField(const void* copy_source, const uint32_t bytes_to_copy, const uint32_t num_elements) :
+  m_data { new uint8_t[bytes_to_copy] },
+  m_num_bytes { bytes_to_copy },
+  m_num_elements { num_elements }
+{
+  memcpy(m_data.get(), copy_source, bytes_to_copy);
+}
+
+/**
+ * @brief initialize a SamBuilderDataField by moving an existing unique_ptr into it (without copying the existing data)
+ *
+ * @note takes ownership of the memory managed by move_source
+ */
+SamBuilderDataField::SamBuilderDataField(std::unique_ptr<uint8_t[]>&& move_source, const uint32_t source_bytes, const uint32_t num_elements) :
+  m_data { move(move_source) },
+  m_num_bytes { source_bytes },
+  m_num_elements { num_elements }
+{}
+
+/**
+ * @brief initialize a SamBuilderDataField via move from an existing field
+ */
+SamBuilderDataField::SamBuilderDataField(SamBuilderDataField&& other) :
+  m_data { move(other.m_data) },
+  m_num_bytes { other.m_num_bytes },
+  m_num_elements { other.m_num_elements }
+{}
+
+/**
+ * @brief move an existing SamBuildDataField into this one
+ */
+SamBuilderDataField& SamBuilderDataField::operator=(SamBuilderDataField&& other) {
+  if ( &other == this )
+    return *this;
+
+  m_data = move(other.m_data);
+  m_num_bytes = other.m_num_bytes;
+  m_num_elements = other.m_num_elements;
+  return *this;
+}
+
+/**
+ * @brief update the field by copying data from a raw pointer (takes no ownership of copy_source)
+ *
+ * @note any previous value of m_data is destroyed via the unique_ptr assignment
+ */
+void SamBuilderDataField::update(const void* copy_source, const uint32_t bytes_to_copy, const uint32_t num_elements) {
+  m_data = unique_ptr<uint8_t[]>{ new uint8_t[bytes_to_copy] };
+  memcpy(m_data.get(), copy_source, bytes_to_copy);
+  m_num_bytes = bytes_to_copy;
+  m_num_elements = num_elements;
+}
+
+/**
+ * @brief update the field by moving an existing unique_ptr into it and taking ownership (without copying the existing data)
+ *
+ * @note any previous value of m_data is destroyed via the unique_ptr assignment
+ */
+void SamBuilderDataField::update(std::unique_ptr<uint8_t[]>&& move_source, const uint32_t source_bytes, const uint32_t num_elements) {
+  m_data = move(move_source);
+  m_num_bytes = source_bytes;
+  m_num_elements = num_elements;
+}
+
+/**
+ * @brief copy this field's byte array into an arbitrary location
+ *
+ * @return pointer to the byte just AFTER the end of the copied data
+ */
+uint8_t* SamBuilderDataField::copy_into(uint8_t* destination) const {
+  memcpy(destination, m_data.get(), m_num_bytes);
+  return destination + m_num_bytes;
+}
+
+}

--- a/gamgee/sam_builder_data_field.h
+++ b/gamgee/sam_builder_data_field.h
@@ -1,0 +1,49 @@
+#ifndef __gamgee__sam_builder_data_field__
+#define __gamgee__sam_builder_data_field__
+
+#include <memory>
+
+namespace gamgee {
+
+/**
+ * @brief class to hold encoded byte arrays for individual data fields (cigar, bases, etc.) during building of a Sam
+ *
+ * Fields can be created/updated either by copying data from raw pointers, or by moving managed pointers
+ * into them without copying. Eg.,
+ *
+ * auto field = SamBuilderDataField{raw_pointer, num_bytes, num_elements};      // does a copy
+ * auto field = SamBuilderDataField{move(unique_ptr), num_bytes, num_elements}; // no copy
+ *
+ * After construction, a field's value can be altered via the update() functions
+ */
+class SamBuilderDataField {
+ public:
+  SamBuilderDataField();                                                                                                             ///<  @brief initialize a SamBuilderDataField to an empty value
+  explicit SamBuilderDataField(const void* copy_source, const uint32_t bytes_to_copy, const uint32_t num_elements);                  ///<  @brief initialize a SamBuilderDataField by copying data from a raw pointer (takes no ownership of copy_source)
+  explicit SamBuilderDataField(std::unique_ptr<uint8_t[]>&& move_source, const uint32_t source_bytes, const uint32_t num_elements);  ///<  @brief initialize a SamBuilderDataField by moving an existing unique_ptr into it and taking ownership (without copying the existing data)
+  SamBuilderDataField(SamBuilderDataField&& other);
+  SamBuilderDataField& operator=(SamBuilderDataField&& other);
+
+  // Fields cannot be copied (only moved), and use default destruction
+  SamBuilderDataField(const SamBuilderDataField& other) = delete;
+  SamBuilderDataField& operator=(const SamBuilderDataField& other) = delete;
+  ~SamBuilderDataField() = default;
+
+  const uint8_t* raw_data_ptr() const { return m_data.get(); }  ///< gets a raw pointer to the data buffer
+  uint32_t num_bytes() const { return m_num_bytes; }            ///< number of bytes in the data buffer
+  uint32_t num_elements() const { return m_num_elements; }      ///< number of elements (cigar operations, bases, etc.) in the data buffer
+  bool is_empty() const { return m_num_bytes == 0; }            ///< does this field have any data?
+
+  void update(const void* copy_source, const uint32_t bytes_to_copy, const uint32_t num_elements);                   ///<  @brief update the field by copying data from a raw pointer (takes no ownership of copy_source)
+  void update(std::unique_ptr<uint8_t[]>&& move_source, const uint32_t source_bytes, const uint32_t num_elements);   ///<  @brief update the field by moving an existing unique_ptr into it and taking ownership (without copying the existing data)
+  uint8_t* copy_into(uint8_t* destination) const;    ///< @brief copy this field's byte array into an arbitrary location
+
+ private:
+  std::unique_ptr<uint8_t[]> m_data;  ///< buffer containing encoded data for the field, managed exclusively by us
+  uint32_t m_num_bytes;               ///< number of bytes in m_data
+  uint32_t m_num_elements;            ///< number of elements (cigar operations, bases, etc.) in m_data
+};
+
+}
+
+#endif /* __gamgee__sam_builder_data_field__ */

--- a/gamgee/sam_header.h
+++ b/gamgee/sam_header.h
@@ -27,6 +27,7 @@ class SamHeader {
   std::shared_ptr<bam_hdr_t> m_header;
 
   friend class SamWriter;
+  friend class SamBuilder;
 };
 
 }

--- a/gamgee/sam_iterator.h
+++ b/gamgee/sam_iterator.h
@@ -46,7 +46,7 @@ class SamIterator {
     /**
      * @brief dereference operator (needed by for-each loop)
      *
-     * @return a persistent Sam object independent from the iterator (a copy of the iterator's object)
+     * @return a Sam object by reference, valid until the next record is fetched (the iterator re-uses memory at each iteration)
      */
     Sam& operator*();
 

--- a/gamgee/sam_tag.h
+++ b/gamgee/sam_tag.h
@@ -1,0 +1,58 @@
+#ifndef __gamgee__sam_tag__
+#define __gamgee__sam_tag__
+
+#include <string>
+
+namespace gamgee {
+
+/**
+ * @brief class to represent a Sam TAG:TYPE:VALUE entry
+ */
+template<class TAG_TYPE>
+class SamTag {
+ public:
+  explicit SamTag(const std::string& name, const TAG_TYPE& value, const bool is_present = true) :
+    m_name { name },
+    m_value { value },
+    m_is_present { is_present }
+  {}
+
+  explicit SamTag(std::string& name, TAG_TYPE&& value, const bool is_present = true) :
+    m_name { name },
+    m_value { std::move(value) },
+    m_is_present { is_present }
+  {}
+
+  SamTag(const SamTag& other) = default;
+  SamTag& operator=(const SamTag& other) = default;
+  ~SamTag() = default;
+
+  SamTag(SamTag&& other) noexcept :
+    m_name { std::move(other.m_name) },
+    m_value { std::move(other.m_value) },
+    m_is_present { other.m_is_present }
+  {}
+
+  SamTag& operator=(SamTag&& other) noexcept {
+    if ( &other == this )
+      return *this;
+
+    m_name = std::move(other.m_name);
+    m_value = std::move(other.m_value);
+    m_is_present = other.m_is_present;
+    return *this;
+  }
+
+  std::string name() const { return m_name; }
+  TAG_TYPE value() const { return m_value; }
+  bool is_present() const { return m_is_present; }
+
+ private:
+  std::string m_name;
+  TAG_TYPE m_value;
+  bool m_is_present;
+};
+
+}
+
+#endif // __gamgee__sam_tag__

--- a/gamgee/utils/hts_memory.cpp
+++ b/gamgee/utils/hts_memory.cpp
@@ -71,6 +71,26 @@ bcf_hdr_t* variant_header_deep_copy(bcf_hdr_t* original) {
   return bcf_hdr_dup(original);
 }
 
+/**
+ * @brief creates a shallow copy of an existing bam1_t: copies
+ *        core fields but not the data buffer or fields related
+ *        to the size of the data buffer
+ */
+bam1_t* sam_shallow_copy(bam1_t* original) {
+  bam1_t* new_read = bam_init1();
+
+  // Copy full struct contents, then zero out fields related to the data
+  *new_read = *original;
+
+  new_read->data = nullptr;
+  new_read->l_data = 0;
+  new_read->m_data = 0;
+  new_read->core.l_qname = 0;
+  new_read->core.l_qseq = 0;
+  new_read->core.n_cigar = 0;
+
+  return new_read;
+}
 
 
 }

--- a/gamgee/utils/hts_memory.h
+++ b/gamgee/utils/hts_memory.h
@@ -58,7 +58,7 @@ bam_hdr_t* sam_header_deep_copy(bam_hdr_t* original);
 bcf1_t* variant_deep_copy(bcf1_t* original); 
 bcf_hdr_t* variant_header_deep_copy(bcf_hdr_t* original);
 
-
+bam1_t* sam_shallow_copy(bam1_t* original);
 
 }
 }

--- a/test/sam_builder_test.cpp
+++ b/test/sam_builder_test.cpp
@@ -1,0 +1,432 @@
+#include "sam_builder.h"
+#include "sam_reader.h"
+
+#include <boost/test/unit_test.hpp>
+#include <stdexcept>
+
+using namespace std;
+using namespace gamgee;
+
+BOOST_AUTO_TEST_CASE( set_name ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_name = original_read.name();
+  auto builder = SamBuilder{original_read};
+  auto modified_read = builder.set_name("new_name").build();
+
+  // Verify that set_name worked, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.name(), "new_name");
+  BOOST_CHECK_EQUAL(original_read.name(), original_read_name);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.cigar() == original_read.cigar());
+  BOOST_CHECK(modified_read.bases() == original_read.bases());
+  BOOST_CHECK(modified_read.base_quals() == original_read.base_quals());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_cigar_by_vector ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_cigar = original_read.cigar().to_string();
+  auto builder = SamBuilder{original_read};
+  auto new_cigar = vector<CigarElement>{ Cigar::make_cigar_element(5, CigarOperator::M),
+                                         Cigar::make_cigar_element(15, CigarOperator::I),
+                                         Cigar::make_cigar_element(56, CigarOperator::M) };
+  auto modified_read = builder.set_cigar(new_cigar).build();
+
+  // Verify that set_cigar worked, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.cigar().to_string(), "5M15I56M");
+  BOOST_CHECK_EQUAL(original_read.cigar().to_string(), original_read_cigar);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == original_read.name());
+  BOOST_CHECK(modified_read.bases() == original_read.bases());
+  BOOST_CHECK(modified_read.base_quals() == original_read.base_quals());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_cigar_by_initializer_list ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_cigar = original_read.cigar().to_string();
+  auto builder = SamBuilder{original_read};
+  auto modified_read = builder.set_cigar({ Cigar::make_cigar_element(5, CigarOperator::M),
+                                           Cigar::make_cigar_element(15, CigarOperator::I),
+                                           Cigar::make_cigar_element(56, CigarOperator::M) }).build();
+
+  // Verify that set_cigar worked, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.cigar().to_string(), "5M15I56M");
+  BOOST_CHECK_EQUAL(original_read.cigar().to_string(), original_read_cigar);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == original_read.name());
+  BOOST_CHECK(modified_read.bases() == original_read.bases());
+  BOOST_CHECK(modified_read.base_quals() == original_read.base_quals());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_cigar_by_string ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_cigar = original_read.cigar().to_string();
+  auto builder = SamBuilder{original_read};
+  auto modified_read = builder.set_cigar("5M15I56M").build();
+
+  // Verify that set_cigar worked, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.cigar().to_string(), "5M15I56M");
+  BOOST_CHECK_EQUAL(original_read.cigar().to_string(), original_read_cigar);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == original_read.name());
+  BOOST_CHECK(modified_read.bases() == original_read.bases());
+  BOOST_CHECK(modified_read.base_quals() == original_read.base_quals());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_cigar_from_existing ) {
+  auto starting_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto starting_read_cigar = starting_read.cigar().to_string();
+  auto builder = SamBuilder{starting_read};
+  auto modified_cigar = string{""};
+
+  for ( auto cigar_donor : SingleSamReader{"testdata/test_paired.bam"} ) {
+    auto cigar = cigar_donor.cigar();
+    if ( cigar.to_string() != "76M" ) {
+      builder.set_cigar(cigar);
+      modified_cigar = cigar.to_string();
+      break;
+    }
+  }
+  auto modified_read = builder.build();
+
+  // Verify that set_cigar worked, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.cigar().to_string(), modified_cigar);
+  BOOST_CHECK_EQUAL(starting_read.cigar().to_string(), starting_read_cigar);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == starting_read.name());
+  BOOST_CHECK(modified_read.bases() == starting_read.bases());
+  BOOST_CHECK(modified_read.base_quals() == starting_read.base_quals());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), starting_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), starting_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_bases_by_vector ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_bases = original_read.bases().to_string();
+  auto builder = SamBuilder{original_read};
+  auto new_bases = vector<Base>{ Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C };
+  auto modified_read = builder.set_bases(new_bases).build();
+
+  // Verify that set_bases worked, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.bases().to_string(), "ACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTC");
+  BOOST_CHECK_EQUAL(original_read.bases().to_string(), original_read_bases);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == original_read.name());
+  BOOST_CHECK(modified_read.cigar() == original_read.cigar());
+  BOOST_CHECK(modified_read.base_quals() == original_read.base_quals());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_bases_by_initializer_list ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_bases = original_read.bases().to_string();
+  auto builder = SamBuilder{original_read};
+  auto modified_read = builder.set_bases({ Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C, Base::C, Base::G, Base::A, Base::A, Base::A, Base::C, Base::G, Base::T, Base::T, Base::C }).build();
+
+  // Verify that set_bases worked, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.bases().to_string(), "ACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTC");
+  BOOST_CHECK_EQUAL(original_read.bases().to_string(), original_read_bases);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == original_read.name());
+  BOOST_CHECK(modified_read.cigar() == original_read.cigar());
+  BOOST_CHECK(modified_read.base_quals() == original_read.base_quals());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_bases_by_string ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_bases = original_read.bases().to_string();
+  auto builder = SamBuilder{original_read};
+  auto modified_read = builder.set_bases("ACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTC").build();
+
+  // Verify that set_bases worked, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.bases().to_string(), "ACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTCCGAAACGTTC");
+  BOOST_CHECK_EQUAL(original_read.bases().to_string(), original_read_bases);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == original_read.name());
+  BOOST_CHECK(modified_read.cigar() == original_read.cigar());
+  BOOST_CHECK(modified_read.base_quals() == original_read.base_quals());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_bases_from_existing ) {
+  auto reader = SingleSamReader{"testdata/test_simple.bam"};
+  auto iter = reader.begin();
+  auto starting_read = *iter;
+  auto starting_read_bases = starting_read.bases().to_string();
+  auto donor_read = ++iter;
+  auto builder = SamBuilder{starting_read};
+  auto modified_read = builder.set_bases(donor_read.bases()).build();
+
+  // Verify that set_bases worked, and that the original read is unaffected
+  BOOST_CHECK(modified_read.bases() == donor_read.bases());
+  BOOST_CHECK_EQUAL(starting_read.bases().to_string(), starting_read_bases);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == starting_read.name());
+  BOOST_CHECK(modified_read.cigar() == starting_read.cigar());
+  BOOST_CHECK(modified_read.base_quals() == starting_read.base_quals());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), starting_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), starting_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_base_quals_by_vector ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_base_quals = original_read.base_quals().to_string();
+  auto builder = SamBuilder{original_read};
+  auto new_base_quals = vector<uint8_t>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6 };
+  auto modified_read = builder.set_base_quals(new_base_quals).build();
+
+  // Verify that set_base_quals worked, and that the original read is unaffected
+  auto modified_read_base_quals = modified_read.base_quals();
+  for ( auto i = 0u; i < modified_read_base_quals.size(); ++i ) {
+    BOOST_CHECK_EQUAL(modified_read_base_quals[i], new_base_quals[i]);
+  }
+  BOOST_CHECK_EQUAL(original_read.base_quals().to_string(), original_read_base_quals);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == original_read.name());
+  BOOST_CHECK(modified_read.cigar() == original_read.cigar());
+  BOOST_CHECK(modified_read.bases() == original_read.bases());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_base_quals_by_initializer_list ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_base_quals = original_read.base_quals().to_string();
+  auto builder = SamBuilder{original_read};
+  auto modified_read = builder.set_base_quals({ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6 }).build();
+
+  // Verify that set_base_quals worked, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.base_quals().to_string(), "1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6 7 8 9 10 1 2 3 4 5 6");
+  BOOST_CHECK_EQUAL(original_read.base_quals().to_string(), original_read_base_quals);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == original_read.name());
+  BOOST_CHECK(modified_read.cigar() == original_read.cigar());
+  BOOST_CHECK(modified_read.bases() == original_read.bases());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_base_quals_from_existing ) {
+  auto reader = SingleSamReader{"testdata/test_simple.bam"};
+  auto iter = reader.begin();
+  auto starting_read = *iter;
+  auto starting_read_base_quals = starting_read.base_quals().to_string();
+  auto donor_read = ++iter;
+  auto builder = SamBuilder{starting_read};
+  auto modified_read = builder.set_base_quals(donor_read.base_quals()).build();
+
+  // Verify that set_base_quals worked, and that the original read is unaffected
+  BOOST_CHECK(modified_read.base_quals() == donor_read.base_quals());
+  BOOST_CHECK_EQUAL(starting_read.base_quals().to_string(), starting_read_base_quals);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == starting_read.name());
+  BOOST_CHECK(modified_read.cigar() == starting_read.cigar());
+  BOOST_CHECK(modified_read.bases() == starting_read.bases());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), starting_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), starting_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_multiple_data_fields ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_cigar = original_read.cigar().to_string();
+  auto original_read_bases = original_read.bases().to_string();
+  auto original_read_base_quals = original_read.base_quals().to_string();
+  auto builder = SamBuilder{original_read};
+  auto modified_read = builder.set_cigar("4M1I1M").set_bases("ACGTTA").set_base_quals({1, 2, 3, 4, 5, 6}).build();
+
+  // Verify that the cigar, bases, and base quals were changed, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.cigar().to_string(), "4M1I1M");
+  BOOST_CHECK_EQUAL(modified_read.bases().to_string(), "ACGTTA");
+  BOOST_CHECK_EQUAL(modified_read.base_quals().to_string(), "1 2 3 4 5 6");
+  BOOST_CHECK_EQUAL(original_read.cigar().to_string(), original_read_cigar);
+  BOOST_CHECK_EQUAL(original_read.bases().to_string(), original_read_bases);
+  BOOST_CHECK_EQUAL(original_read.base_quals().to_string(), original_read_base_quals);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == original_read.name());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_multiple_data_fields_one_time_build ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+  auto original_read_cigar = original_read.cigar().to_string();
+  auto original_read_bases = original_read.bases().to_string();
+  auto original_read_base_quals = original_read.base_quals().to_string();
+  auto builder = SamBuilder{original_read};
+  builder.set_cigar("4M1I1M").set_bases("ACGTTA").set_base_quals({1, 2, 3, 4, 5, 6});
+  auto modified_read = builder.one_time_build();
+
+  // Verify that the cigar, bases, and base quals were changed, and that the original read is unaffected
+  BOOST_CHECK_EQUAL(modified_read.cigar().to_string(), "4M1I1M");
+  BOOST_CHECK_EQUAL(modified_read.bases().to_string(), "ACGTTA");
+  BOOST_CHECK_EQUAL(modified_read.base_quals().to_string(), "1 2 3 4 5 6");
+  BOOST_CHECK_EQUAL(original_read.cigar().to_string(), original_read_cigar);
+  BOOST_CHECK_EQUAL(original_read.bases().to_string(), original_read_bases);
+  BOOST_CHECK_EQUAL(original_read.base_quals().to_string(), original_read_base_quals);
+
+  // Verify that other fields were inherited from the original read
+  BOOST_CHECK(modified_read.name() == original_read.name());
+  BOOST_CHECK_EQUAL(modified_read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(modified_read.alignment_start(), original_read.alignment_start());
+}
+
+BOOST_AUTO_TEST_CASE( set_multiple_data_fields_from_scratch ) {
+  auto header = SingleSamReader{"testdata/test_simple.bam"}.header();
+  auto builder = SamBuilder{header};
+  builder.set_name("foo").set_cigar("1M1I1M").set_bases("ACT").set_base_quals({1, 2, 3});
+  builder.set_chromosome(1).set_alignment_start(142).set_mate_alignment_start(199);
+  auto constructed_read = builder.build();
+
+  BOOST_CHECK_EQUAL(constructed_read.name(), "foo");
+  BOOST_CHECK_EQUAL(constructed_read.cigar().to_string(), "1M1I1M");
+  BOOST_CHECK_EQUAL(constructed_read.bases().to_string(), "ACT");
+  BOOST_CHECK_EQUAL(constructed_read.base_quals().to_string(), "1 2 3");
+  BOOST_CHECK_EQUAL(constructed_read.chromosome(), 1);
+  BOOST_CHECK_EQUAL(constructed_read.alignment_start(), 142);
+  BOOST_CHECK_EQUAL(constructed_read.mate_alignment_start(), 199);
+}
+
+BOOST_AUTO_TEST_CASE( reconstruct_complete_read ) {
+  auto original_read = *(SingleSamReader{"testdata/test_simple.bam"}.begin());
+
+  // Start from scratch with only the header, and see if we can construct a full copy of original_read
+  auto builder = SamBuilder{original_read.header()};
+
+  builder.set_name(original_read.name()).set_cigar(original_read.cigar()).set_bases(original_read.bases()).set_base_quals(original_read.base_quals());
+  builder.set_chromosome(original_read.chromosome()).set_alignment_start(original_read.alignment_start());
+  builder.set_mate_chromosome(original_read.mate_chromosome()).set_mate_alignment_start(original_read.mate_alignment_start());
+  original_read.paired() ? builder.set_paired() : builder.set_not_paired();
+  original_read.unmapped() ? builder.set_unmapped() : builder.set_not_unmapped();
+  original_read.next_unmapped() ? builder.set_next_unmapped() : builder.set_not_next_unmapped();
+  original_read.reverse() ? builder.set_reverse() : builder.set_not_reverse();
+  original_read.next_reverse() ? builder.set_next_reverse() : builder.set_not_next_reverse();
+  original_read.first() ? builder.set_first() : builder.set_not_first();
+  original_read.last() ? builder.set_last() : builder.set_not_last();
+  original_read.secondary() ? builder.set_secondary() : builder.set_not_secondary();
+  original_read.fail() ? builder.set_fail() : builder.set_not_fail();
+  original_read.duplicate() ? builder.set_duplicate() : builder.set_not_duplicate();
+  original_read.supplementary() ? builder.set_supplementary() : builder.set_not_supplementary();
+
+  auto read = builder.build();
+
+  BOOST_CHECK_EQUAL(read.name(), original_read.name());
+  BOOST_CHECK(read.cigar() == original_read.cigar());
+  BOOST_CHECK(read.bases() == original_read.bases());
+  BOOST_CHECK(read.base_quals() == original_read.base_quals());
+  BOOST_CHECK_EQUAL(read.chromosome(), original_read.chromosome());
+  BOOST_CHECK_EQUAL(read.alignment_start(), original_read.alignment_start());
+  BOOST_CHECK_EQUAL(read.mate_chromosome(), original_read.mate_chromosome());
+  BOOST_CHECK_EQUAL(read.mate_alignment_start(), original_read.mate_alignment_start());
+  BOOST_CHECK_EQUAL(read.paired(), original_read.paired());
+  BOOST_CHECK_EQUAL(read.unmapped(), original_read.unmapped());
+  BOOST_CHECK_EQUAL(read.next_unmapped(), original_read.next_unmapped());
+  BOOST_CHECK_EQUAL(read.reverse(), original_read.reverse());
+  BOOST_CHECK_EQUAL(read.next_reverse(), original_read.next_reverse());
+  BOOST_CHECK_EQUAL(read.first(), original_read.first());
+  BOOST_CHECK_EQUAL(read.last(), original_read.last());
+  BOOST_CHECK_EQUAL(read.secondary(), original_read.secondary());
+  BOOST_CHECK_EQUAL(read.fail(), original_read.fail());
+  BOOST_CHECK_EQUAL(read.duplicate(), original_read.duplicate());
+  BOOST_CHECK_EQUAL(read.supplementary(), original_read.supplementary());
+}
+
+BOOST_AUTO_TEST_CASE( build_multiple_reads ) {
+  auto header = SingleSamReader{"testdata/test_simple.bam"}.header();
+  auto builder = SamBuilder{header};
+  builder.set_name("foo").set_cigar("1M1I1M").set_bases("ACT").set_base_quals({1, 2, 3});
+  builder.set_chromosome(1).set_alignment_start(142).set_mate_alignment_start(199);
+  auto constructed_read = builder.build();
+
+  BOOST_CHECK_EQUAL(constructed_read.name(), "foo");
+  BOOST_CHECK_EQUAL(constructed_read.cigar().to_string(), "1M1I1M");
+  BOOST_CHECK_EQUAL(constructed_read.bases().to_string(), "ACT");
+  BOOST_CHECK_EQUAL(constructed_read.base_quals().to_string(), "1 2 3");
+  BOOST_CHECK_EQUAL(constructed_read.chromosome(), 1);
+  BOOST_CHECK_EQUAL(constructed_read.alignment_start(), 142);
+  BOOST_CHECK_EQUAL(constructed_read.mate_alignment_start(), 199);
+
+  auto second_read = builder.set_chromosome(2).set_cigar("2M1I").set_bases("GGA").build();
+
+  BOOST_CHECK_EQUAL(second_read.name(), "foo");
+  BOOST_CHECK_EQUAL(second_read.cigar().to_string(), "2M1I");
+  BOOST_CHECK_EQUAL(second_read.bases().to_string(), "GGA");
+  BOOST_CHECK_EQUAL(second_read.base_quals().to_string(), "1 2 3");
+  BOOST_CHECK_EQUAL(second_read.chromosome(), 2);
+  BOOST_CHECK_EQUAL(second_read.alignment_start(), 142);
+  BOOST_CHECK_EQUAL(second_read.mate_alignment_start(), 199);
+}
+
+BOOST_AUTO_TEST_CASE( set_illegal_cigar ) {
+  auto header = SingleSamReader{"testdata/test_simple.bam"}.header();
+  auto builder = SamBuilder{header};
+  builder.set_name("foo").set_bases("ACT").set_base_quals({1, 2, 3});
+
+  // Should throw an exception, since the cigar is invalid
+  BOOST_CHECK_THROW(builder.set_cigar("3F"), logic_error);
+}
+
+BOOST_AUTO_TEST_CASE( set_mismatching_bases_and_quals ) {
+  auto header = SingleSamReader{"testdata/test_simple.bam"}.header();
+  auto builder = SamBuilder{header};
+  builder.set_name("foo").set_cigar("3M").set_bases("ACT").set_base_quals({1, 2});
+
+  // Should throw an exception, since the number of base qualities does not equal the number of bases
+  BOOST_CHECK_THROW(builder.build(), logic_error);
+}
+
+BOOST_AUTO_TEST_CASE( set_mismatching_cigar_and_bases ) {
+  auto header = SingleSamReader{"testdata/test_simple.bam"}.header();
+  auto builder = SamBuilder{header};
+  builder.set_name("foo").set_cigar("2M").set_bases("ACT").set_base_quals({1, 2, 3});
+
+  // Should throw an exception, since the cigar does not match the sequence length
+  BOOST_CHECK_THROW(builder.build(), logic_error);
+}
+
+BOOST_AUTO_TEST_CASE( missing_required_data_field ) {
+  auto header = SingleSamReader{"testdata/test_simple.bam"}.header();
+  auto builder = SamBuilder{header};
+  builder.set_name("foo").set_bases("ACT").set_base_quals({1, 2, 3});
+
+  // Should throw an exception, since we're missing a cigar
+  BOOST_CHECK_THROW(builder.build(), logic_error);
+}
+
+BOOST_AUTO_TEST_CASE( build_without_validation ) {
+  auto header = SingleSamReader{"testdata/test_simple.bam"}.header();
+  auto builder = SamBuilder{header, false}; // disable validation
+  builder.set_name("foo").set_cigar("2M").set_bases("ACT").set_base_quals({1, 2, 3});
+
+  // Should not throw, since we've disabled validation
+  auto read = builder.build();
+
+  BOOST_CHECK_EQUAL(read.name(), "foo");
+  BOOST_CHECK_EQUAL(read.cigar().to_string(), "2M");
+  BOOST_CHECK_EQUAL(read.bases().to_string(), "ACT");
+  BOOST_CHECK_EQUAL(read.base_quals().to_string(), "1 2 3");
+}
+


### PR DESCRIPTION
-Created SamBuilder to build Sam objects from existing data or
 from scratch
    -unlike in-place setters in Sam class, can restructure and
     manipulate the variable-length read data in arbitrary ways
    -offers both repeatable builds and the option of a (slightly
     more efficient) one-time build
    -supports setting data fields using existing reads, vectors,
     initializer lists, and strings (least efficient)
    -basic validation of logical consistency of read before each
     build (eg., number of base qualities must match number of bases)

-In-place setters for data fields in the Sam class when more radical
 restructuring is not needed

-Basic support for Sam TAG:TYPE:VALUE fields
    -read-only support for integer, double/float, char, and string
     valued tags
    -can copy an existing read's tag in their entirety using SamBuilder,
     but can't yet set individual tags

-Cigar::make_cigar_element() to ease creation of vectors/initializer_lists
 of cigar elements

-Comprehensive tests for SamBuilder and SamTag

TODOS:

   -support for tag fields of type H (byte array) and B (numeric array)
   -add ability to set/modify individual tags in SamBuilder
   -properly set the core.isize field in SamBuilder (currently the
    only field not yet fully supported apart from the tags)
   -fix issue with htslib bam_aux2i() and bam_aux2f() return value
    ambiguity when field is of wrong type
