### PR TITLE
VariantHeader: rename contigs to chromosomes

### DIFF
--- a/gamgee/variant_header.cpp
+++ b/gamgee/variant_header.cpp
@@ -58,7 +58,7 @@ vector<string> VariantHeader::samples() const {
   return utils::hts_string_array_to_vector(m_header->samples, uint32_t(bcf_hdr_nsamples(m_header)));
 }
 
-vector<string> VariantHeader::contigs() const {
+vector<string> VariantHeader::chromosomes() const {
   return find_fields_of_type(m_header.get(), BCF_HL_CTG);
 }
 

--- a/gamgee/variant_header.h
+++ b/gamgee/variant_header.h
@@ -33,7 +33,7 @@ class VariantHeader {
 
   std::vector<std::string> filters()       const; ///< @brief builds a vector with the filters 
   std::vector<std::string> samples()       const; ///< @brief builds a vector with the names of the samples 
-  std::vector<std::string> contigs()       const; ///< @brief builds a vector with the contigs 
+  std::vector<std::string> chromosomes()   const; ///< @brief builds a vector with the contigs 
   std::vector<std::string> info_fields()   const; ///< @brief builds a vector with the info fields 
   std::vector<std::string> format_fields() const; ///< @brief builds a vector with the format fields
   bool has_format_field(const std::string)        const; ///< @brief checks if format field has the given field

--- a/test/variant_header_test.cpp
+++ b/test/variant_header_test.cpp
@@ -13,15 +13,15 @@ void check_fields(T actual, T truth) {
 }
 
 BOOST_AUTO_TEST_CASE( variant_header_builder_simple_building ) {
-  const auto samples = vector<string>{"S1", "S292", "S30034"}; 
-  const auto contigs = vector<string>{"chr1", "chr2", "chr3", "chr4"}; 
-  const auto filters = vector<string>{"LOW_QUAL", "PASS", "VQSR_FAILED"};
-  const auto infos   = vector<string>{"DP", "MQ", "RankSum"};
-  const auto formats = vector<string>{"GQ", "PL", "DP"};
+  const auto samples     = vector<string>{"S1", "S292", "S30034"};
+  const auto chromosomes = vector<string>{"chr1", "chr2", "chr3", "chr4"};
+  const auto filters     = vector<string>{"LOW_QUAL", "PASS", "VQSR_FAILED"};
+  const auto infos       = vector<string>{"DP", "MQ", "RankSum"};
+  const auto formats     = vector<string>{"GQ", "PL", "DP"};
   auto builder = VariantHeaderBuilder{};
   builder.add_source("Gamgee api test");
   builder.advanced_add_arbitrary_line("##unused=<XX=AA,Description=\"Unused generic\">");
-  for (const auto& contig : contigs) 
+  for (const auto& contig : chromosomes) 
     builder.add_contig(contig, "234");
   for (const auto& sample : samples)
     builder.add_sample(sample);
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE( variant_header_builder_simple_building ) {
   for (const auto& format : formats) 
     builder.add_format_field(format, "13", "Float", "nothing", "goat=shank");
   const auto vh = builder.build();
-  check_fields(vh.contigs(), contigs);
+  check_fields(vh.chromosomes(), chromosomes);
   check_fields(vh.samples(), samples);
   check_fields(vh.filters(), filters);
   check_fields(vh.info_fields(), infos);


### PR DESCRIPTION
In order to keep the entire library consistent, the naming must be
standardized.

fixes #93
