### PR TITLE
gamgee.h: one header to rule them all

### DIFF
--- a/gamgee/gamgee.h
+++ b/gamgee/gamgee.h
@@ -1,0 +1,19 @@
+#ifndef __gamgee__gamgee__
+#define __gamgee__gamgee__
+
+#include "sam.h"
+#include "sam_reader.h"
+#include "sam_writer.h"
+#include "sam_builder.h"
+
+#include "variant.h"
+#include "variant_reader.h"
+#include "variant_writer.h"
+#include "variant_header_builder.h"
+
+#include "fastq.h"
+#include "fastq_reader.h"
+
+#include "is_missing.h"
+
+#endif  /* __gamgee__gamgee__ */


### PR DESCRIPTION
-One header that gets you all of the gamgee includes (minus the utils)

-For client code (eg., foghorn) where convenience is desired. Should
 not be used within gamgee itself, to cut down on compilation time and
 also to make it possible to still cherry-pick individual headers in client
 code when compile time is critical.

-Avoid having to type silly things like #include "is_missing.h"

-Should be continually updated as gamgee expands (pull requests should
 be rejected if they don't update gamgee.h as necessary)
