### PR TITLE
MultipleVariantReader and MultipleVariantIterator

### DIFF
--- a/gamgee/multiple_variant_iterator.cpp
+++ b/gamgee/multiple_variant_iterator.cpp
@@ -1,0 +1,76 @@
+#include "multiple_variant_iterator.h"
+
+namespace gamgee {
+
+MultipleVariantIterator::MultipleVariantIterator() :
+  m_queue {},
+  m_variant_vector {}
+{}
+
+MultipleVariantIterator::MultipleVariantIterator(const std::vector<vcfFile*> variant_files, const std::shared_ptr<bcf_hdr_t> variant_header) :
+  m_queue {},
+  m_variant_vector {}
+{
+  m_variant_vector.reserve(variant_files.size());
+  for (auto i = 0u; i < variant_files.size(); i++) {
+    m_queue.push(std::make_shared<VariantIterator>(variant_files[i], variant_header));
+  }
+  fetch_next_vector();
+}
+
+MultipleVariantIterator::MultipleVariantIterator(MultipleVariantIterator&& original) :
+  m_queue {std::move(original.m_queue)},
+  m_variant_vector {std::move(original.m_variant_vector)}
+{}
+
+std::vector<Variant>& MultipleVariantIterator::operator*() {
+  return m_variant_vector;
+}
+
+std::vector<Variant>& MultipleVariantIterator::operator++() {
+  fetch_next_vector();
+  return m_variant_vector;
+}
+
+// NOTE: this method does the minimal work necessary to determine that we have reached the end of iteration
+// it is NOT a valid general-purpose inequality method
+bool MultipleVariantIterator::operator!=(const MultipleVariantIterator& rhs) {
+  return !(m_variant_vector.empty() && rhs.m_variant_vector.empty());
+}
+
+bool MultipleVariantIterator::Comparator::operator()(const std::shared_ptr<VariantIterator>& left, const std::shared_ptr<VariantIterator>& right) {
+  if ((**left).chromosome() > (**right).chromosome())
+    return true;
+
+  if ((**left).chromosome() < (**right).chromosome())
+    return false;
+
+  return (**left).alignment_start() > (**right).alignment_start();
+}
+
+void MultipleVariantIterator::fetch_next_vector() {
+  m_variant_vector.clear();
+  auto current_chrom = 0u;
+  auto current_start = 0u;
+
+  while (!m_queue.empty()) {
+    const auto top_iterator = m_queue.top();
+    const auto& variant = **top_iterator;
+
+    if (!m_variant_vector.empty() && !(variant.chromosome() == current_chrom && variant.alignment_start() == current_start))
+      break;
+    else {
+      m_variant_vector.push_back(variant);
+      current_chrom = variant.chromosome();
+      current_start = variant.alignment_start();
+
+      m_queue.pop();
+      top_iterator->operator++();
+      if (! top_iterator->empty())
+        m_queue.push(std::move(top_iterator));
+    }
+  }
+}
+
+}
+

--- a/gamgee/multiple_variant_iterator.h
+++ b/gamgee/multiple_variant_iterator.h
@@ -1,0 +1,83 @@
+#ifndef __gamgee__multiple_variant_iterator__
+#define __gamgee__multiple_variant_iterator__
+
+#include "htslib/vcf.h"
+
+#include "variant.h"
+#include "variant_iterator.h"
+
+#include <memory>
+#include <queue>
+
+namespace gamgee {
+
+/**
+ * @brief Utility class to enable for-each style iteration in the MultipleVariantReader class
+ */
+class MultipleVariantIterator {
+ public:
+
+  /**
+   * @brief creates an empty iterator (used for the end() method) 
+   */
+  MultipleVariantIterator();
+
+  /**
+   * @brief initializes a new iterator based on a vector of input files (vcf or bcf)
+   *
+   * @param variant_files   vector of vcf/bcf files opened via the bcf_open() macro from htslib
+   * @param variant_headers the combined vcf/bcf file header
+   */
+  MultipleVariantIterator(const std::vector<vcfFile*> variant_files, const std::shared_ptr<bcf_hdr_t> variant_header);
+
+  /**
+   * @brief a MultipleVariantIterator move constructor guarantees all objects will have the same state.
+   */
+  MultipleVariantIterator(MultipleVariantIterator&&);
+
+  /**
+   * @brief pseudo-inequality operator (needed by for-each loop)
+   *
+   * NOTE: this method does the minimal work necessary to determine that we have reached the end of iteration.
+   * it is NOT a valid general-purpose inequality method.
+   *
+   * @param rhs the other MultipleVariantIterator to compare to
+   *
+   * @return whether both iterators have entered their end states
+   */
+  bool operator!=(const MultipleVariantIterator& rhs);
+
+  /**
+   * @brief dereference operator (needed by for-each loop)
+   *
+   * @return a reference to the iterator's Variant vector
+   */
+  std::vector<Variant>& operator*();
+
+  /**
+   * @brief advances the iterator, fetching the next vector
+   *
+   * @return a reference to the iterator's Variant vector
+   */
+  std::vector<Variant>& operator++();
+
+ private:
+  // fetches the next Variant vector
+  void fetch_next_vector();
+
+  // comparison class for genomic locations in the priority queue
+  class Comparator {
+   public:
+    bool operator()(const std::shared_ptr<VariantIterator>& left, const std::shared_ptr<VariantIterator>& right);
+  };
+
+  // the individual file iterators
+  std::priority_queue<std::shared_ptr<VariantIterator>, std::vector<std::shared_ptr<VariantIterator>>, Comparator> m_queue;
+
+  // caches next Variant vector
+  std::vector<Variant> m_variant_vector;
+};
+
+}  // end namespace gamgee
+
+#endif	// __gamgee__multiple_variant_iterator__

--- a/gamgee/multiple_variant_reader.h
+++ b/gamgee/multiple_variant_reader.h
@@ -1,0 +1,122 @@
+#ifndef __gamgee__multiple_variant_reader__
+#define __gamgee__multiple_variant_reader__
+
+#include "htslib/vcf.h"
+
+#include "variant_header.h"
+#include "utils/hts_memory.h"
+
+namespace gamgee {
+
+/**
+ * @brief Utility class to read multiple VCF/BCF files with an appropriate iterator in a for-each loop.
+ *
+ * This class is designed to parse files in for-each loops with the following signature:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * for (auto& vector : MultipleVariantReader<MultipleVariantIterator>{filenames})
+ *   do_something_with_vector(vector);
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * You can also use it with stdin or any other stream by using the default constructor
+ * or passing in an empty string for a filename, like so:
+ * 
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * for (auto& vector : MultipleVariantReader<MultipleVariantIterator>{filename1, stream2})
+ *   do_something_with_vector(vector);
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+template<class ITERATOR>
+class MultipleVariantReader {
+ public:
+
+  /**
+   * @brief enables reading records in multiple files (vcf or bcf)
+   *
+   * @param filenames the names of the variant files
+   * @param should we validate that the header files have identical chromosomes?  default = true
+   */
+  MultipleVariantReader(const std::vector<std::string>& filenames, const bool validate_headers = true) :
+    m_variant_files { },
+    m_variant_header { nullptr } {
+    for (const auto& filename : filenames) {
+      // TODO? check for maximum one stream
+      vcfFile* file_ptr = bcf_open(filename.empty() ? "-" : filename.c_str(), "r");
+      m_variant_files.push_back(file_ptr);
+
+      const auto& header_ptr = utils::make_shared_variant_header(bcf_hdr_read(file_ptr));
+      if (m_variant_header == nullptr)
+        m_variant_header = header_ptr;
+
+      if (validate_headers)
+        validate_header(header_ptr);
+    }
+  }
+
+  /**
+   * @brief MultipleVariantReader should never be copied, but it can be moved
+   */
+  MultipleVariantReader(MultipleVariantReader&& other) :
+    m_variant_files {std::move(other.m_variant_files)},
+    m_variant_header {std::move(other.m_variant_header)}
+  {}
+
+  /**
+   * @brief closes the file streams if they are files
+   */
+  ~MultipleVariantReader() {
+    for (auto file_ptr : m_variant_files)
+      bcf_close(file_ptr);
+  }
+
+  /**
+   * @brief a MultipleVariantReader cannot be copied safely, as it is iterating over streams.
+   */
+  MultipleVariantReader(const MultipleVariantReader&) = delete;
+
+  /**
+   * @brief creates an ITERATOR pointing at the start of the input streams (needed by for-each
+   * loop)
+   *
+   * @return an ITERATOR ready to start parsing the files
+   */
+  ITERATOR begin() const {
+    return ITERATOR{m_variant_files, m_variant_header};
+  }
+
+  /**
+   * @brief creates a default ITERATOR (needed by for-each loop)
+   *
+   * @return an ITERATOR that will match the end status of the iterator at the end of the streams
+   */
+  ITERATOR end() const {
+    return ITERATOR{};
+  }
+
+  /**
+   * @brief returns a representative header for the files being read
+   *
+   * @return a VariantHeader object constructed from the header of the first file read
+   */
+  const inline VariantHeader header() { return VariantHeader {m_variant_header}; }
+
+  class HeaderException : public std::runtime_error {
+   public:
+    HeaderException() : std::runtime_error("Error: chromosomes in header files are inconsistent") { }
+  };
+ private:
+  std::vector<vcfFile*> m_variant_files;                ///< vector of the internal file structures of the variant files
+  std::shared_ptr<bcf_hdr_t> m_variant_header;          ///< the internal header structure of the first variant file
+
+  ///< confirms that the chromosomes in the headers of all of the input files are identical
+  // TODO? only handles chromosome names, not lengths
+  void validate_header(const std::shared_ptr<bcf_hdr_t>& other_header_ptr) {
+    const auto& other_header = VariantHeader{other_header_ptr};
+    if (header().chromosomes() != other_header.chromosomes())
+      throw HeaderException{};
+  }
+};
+
+}  // end namespace gamgee
+
+#endif /* defined(__gamgee__multiple_variant_reader__) */

--- a/gamgee/variant_iterator.cpp
+++ b/gamgee/variant_iterator.cpp
@@ -38,6 +38,11 @@ Variant& VariantIterator::operator++() {
 bool VariantIterator::operator!=(const VariantIterator& rhs) {
   return m_variant_file_ptr != rhs.m_variant_file_ptr;
 }
+
+bool VariantIterator::empty() {
+  return m_variant_file_ptr == nullptr;
+}
+
 /**
  * @brief pre-fetches the next variant record
  * @warning we're reusing the existing htslib memory, so users should be aware that all objects from the previous iteration are now stale unless a deep copy has been performed

--- a/gamgee/variant_iterator.h
+++ b/gamgee/variant_iterator.h
@@ -58,6 +58,13 @@ class VariantIterator {
    */
   Variant& operator++();
 
+  /**
+   * @brief returns whether the iterator has no additional records
+   *
+   * @return true if the the iterator has no additional records
+   */
+  bool empty();
+
  private:
   vcfFile * m_variant_file_ptr;                    ///< pointer to the vcf/bcf file
   std::shared_ptr<bcf_hdr_t> m_variant_header_ptr; ///< pointer to the variant header

--- a/test/multiple_variant_reader_test.cpp
+++ b/test/multiple_variant_reader_test.cpp
@@ -1,0 +1,130 @@
+#include "multiple_variant_reader.h"
+#include "multiple_variant_iterator.h"
+#include "is_missing.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace gamgee;
+
+BOOST_AUTO_TEST_CASE( multi_variant_reader_validation )
+{
+  const std::vector<std::string> filenames1{"testdata/test_variants.vcf", "testdata/extra_header.vcf"};
+  const std::vector<std::string> filenames2{"testdata/test_variants.vcf", "testdata/missing_header.vcf"};
+
+  // validate mismatched headers by default
+  for (const auto filenames_v : {filenames1, filenames2})
+    BOOST_CHECK_THROW(
+      auto reader = MultipleVariantReader<MultipleVariantIterator>(filenames_v),
+      std::runtime_error
+      // this does not work for some reason
+      // MultipleVariantReader::HeaderException
+    );
+
+  // don't validate mismatched headers
+  for (const auto filenames_v : {filenames1, filenames2})
+    auto reader = MultipleVariantReader<MultipleVariantIterator>(filenames_v, false);
+}
+
+// copied from variant_reader_test
+BOOST_AUTO_TEST_CASE( multi_variant_reader )
+{
+  const auto truth_contigs = vector<uint32_t>{0, 1, 1, 1, 2};
+  const auto truth_alignment_starts = vector<uint32_t>{10000000, 10001000, 10002000, 10003000, 10004000};
+  const auto truth_n_alleles = vector<uint32_t>{2, 2, 2, 2, 3};
+  const auto truth_filter_first = vector<string>{"PASS", "PASS", "LOW_QUAL", "NOT_DEFINED", "PASS"};
+  const auto truth_filter_size = vector<uint32_t>{1,1,1,1,2};
+  const auto truth_quals = vector<float>{80,8.4,-1,-1,-1};
+  const auto truth_ref = vector<string>{"T", "GG", "TAGTGQA", "A", "GAT"};
+  const vector< vector<string>> truth_alt = {  { "C" } , {"AA"},  {"T"},  {"AGCT"},  {"G","GATAT"}};
+  MultipleVariantReader<MultipleVariantIterator> reader{{"testdata/test_variants.vcf", "testdata/test_variants.bcf"}, false};
+  auto position_counter = 0u;
+  for (const auto& vec : reader) {
+    for (const auto& record : vec) {
+      BOOST_CHECK_EQUAL(record.ref(), truth_ref[position_counter]);
+      BOOST_CHECK_EQUAL(record.chromosome(), truth_contigs[position_counter]);
+      BOOST_CHECK_EQUAL(record.alignment_start(), truth_alignment_starts[position_counter]);
+      BOOST_CHECK_EQUAL(record.n_alleles(), truth_n_alleles[position_counter]);
+      BOOST_CHECK_EQUAL(record.n_samples(), 3);
+      BOOST_CHECK(record.has_filter(truth_filter_first[position_counter])); // check the has_filter member function
+
+
+      // check for quals (whether missing or parsed)
+      if (truth_quals[position_counter] < 0)
+	BOOST_CHECK(is_missing(record.qual()));
+      else
+	BOOST_CHECK_EQUAL(record.qual(), truth_quals[position_counter]);
+
+      auto alt = record.alt();
+      BOOST_CHECK_EQUAL_COLLECTIONS(alt.begin(), alt.end(), truth_alt[position_counter].begin(), truth_alt[position_counter].end());
+
+      // check that absent filters are really absent
+      const auto absent_filter = record.has_filter("LOW_QUAL");
+      if (position_counter != 2)
+	BOOST_CHECK(absent_filter == false);
+
+      // test filters getter api
+      const auto filters = record.filters();
+      BOOST_CHECK_EQUAL(filters.size(), truth_filter_size[position_counter]); // checking size member function
+      BOOST_CHECK_EQUAL(filters[0], truth_filter_first[position_counter]);  // checking random access
+      BOOST_CHECK_EQUAL(count_if(filters.begin(), filters.end(), [](const auto x){return x == x;}), truth_filter_size[position_counter]); // checking iteration in functional style
+
+      // testing genotype_quals accessors
+      const auto gqs = record.genotype_quals();
+      BOOST_CHECK_EQUAL(gqs[1][0], 35); // checking random access operators
+      for_each(gqs.begin(), gqs.end(), [](const VariantFieldValue<int32_t>& x) { BOOST_CHECK_EQUAL(x[0], 35); }); // testing std library functional call at the samples level
+
+      // testing phred_likelihoods accessors
+      const auto pls = record.phred_likelihoods();
+      BOOST_CHECK_EQUAL(pls[0][0], 10); // testing random access
+      BOOST_CHECK_EQUAL(pls[1][1], 10);
+      BOOST_CHECK_EQUAL(pls[2][2], 0);
+      for(const auto& sample_pl : pls) { // testing for-each iteration at the samples level
+	BOOST_CHECK_EQUAL(1, count_if(sample_pl.begin(), sample_pl.end(), [](const auto& x) { return x == 0; })); // testing std library functional call at the sample value level
+	for(const auto& value_pl : sample_pl)  // testing for-each iteration at the sample value level
+	  BOOST_CHECK_EQUAL(value_pl, value_pl); // I just want to make sure that this level of iteration is supported, the values don't matter anymore at this point
+      }
+
+      // check genotype accessors
+      BOOST_CHECK(record.is_hom_ref(1));
+      BOOST_CHECK(record.is_het(0));
+      BOOST_CHECK(record.is_hom_var(2));
+
+      // test generic FLOAT
+      const auto af = record.generic_float_format_field("AF");
+      for_each(af.begin(), af.end(), [](const auto& s) {BOOST_CHECK_CLOSE(s[1], 2.2, 0.001);}); // checking float std library functional call at the samples level
+      for (const auto& s : af) {
+	for_each(s.begin(), s.end(), [](const auto& x) {BOOST_CHECK_EQUAL(x,x);}); // checking float std library functional call at the sample value level
+	BOOST_CHECK_CLOSE(s[0], 3.1, 0.001);
+	BOOST_CHECK_CLOSE(s[1], 2.2, 0.001);
+      }
+
+      // test generic STRING (disabled because it is not working!)
+      // const auto as = record.generic_string_format_field("AS");
+      // for_each(as.begin(), as.end(), [](const auto& s) {BOOST_CHECK_EQUAL(s[1], "CATE");}); // checking string std library functional call at the samples level
+      // for (const auto& s : as) {
+      //   for_each(s.begin(), s.end(), [](const auto& x) {BOOST_CHECK_EQUAL(x,x);}); // checking string std library functional call at the sample value level
+      //   BOOST_CHECK_EQUAL(s[0], "ABA");
+      //   BOOST_CHECK_EQUAL(s[1], "CATE");
+      // }
+
+      const auto validated_actual = record.generic_boolean_info_field("VALIDATED");
+      const auto validated_expected = std::vector<bool>{position_counter == 0};
+      BOOST_CHECK_EQUAL_COLLECTIONS(validated_actual.begin(), validated_actual.end(), validated_expected.begin(), validated_expected.end());
+
+      const auto an = record.generic_integer_info_field("AN");
+      BOOST_CHECK_EQUAL(an.size(), 1);
+      BOOST_CHECK_EQUAL(an[0], 6);
+
+      const auto af_actual = record.generic_float_info_field("AF");
+      const auto af_expected = position_counter == 4 ? std::vector<float>{0.5, 0} : std::vector<float>{0.5};
+      BOOST_CHECK_EQUAL_COLLECTIONS(af_actual.begin(), af_actual.end(), af_expected.begin(), af_expected.end());
+
+      const auto desc_actual = record.generic_string_info_field("DESC");
+      const auto desc_expected = position_counter == 0 ? std::vector<string>{"Test1,Test2"} : std::vector<string>{};
+      BOOST_CHECK_EQUAL_COLLECTIONS(desc_actual.begin(), desc_actual.end(), desc_expected.begin(), desc_expected.end());
+    }
+    ++position_counter;
+  }
+  BOOST_CHECK_EQUAL(position_counter, 5u);
+}

--- a/test/variant_reader_test.cpp
+++ b/test/variant_reader_test.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE( single_variant_reader )
   const auto truth_filter_size = vector<uint32_t>{1,1,1,1,2};
   const auto truth_quals = vector<float>{80,8.4,-1,-1,-1};
   const auto truth_ref = vector<string>{"T", "GG", "TAGTGQA", "A", "GAT"};
-  const vector< vector<string> > truth_alt = {  { "C" } , {"AA"},  {"T"},  {"AGCT"},  {"G","GATAT"}};
+  const vector< vector<string>> truth_alt = {  { "C" } , {"AA"},  {"T"},  {"AGCT"},  {"G","GATAT"}};
   for (const auto& filename : {"testdata/test_variants.vcf", "testdata/test_variants.bcf"}) {
     auto record_counter = 0u;
     for (const auto& record : SingleVariantReader{filename}) {

--- a/testdata/extra_header.vcf
+++ b/testdata/extra_header.vcf
@@ -1,0 +1,24 @@
+##fileformat=VCFv4.1
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=VALIDATED,Number=0,Type=Flag,Description="Validated By Follow-up Experiment">
+##INFO=<ID=DESC,Number=.,Type=String,Description="Custom Description">
+##FILTER=<ID=PASS,Description=All filters passed>
+##FILTER=<ID=LOW_QUAL,Description=Low quality call>
+##FILTER=<ID=MISSED,Description=Missed by the variant caller>
+##FILTER=<ID=NOT_DEFINED,Description=Undefined filter>
+##contig=<ID=1,Length=300000000,Description=the first chromosome>
+##contig=<ID=20,Length=64000000>
+##contig=<ID=22,Length=120000000>
+##contig=<ID=23,Length=120000000>
+##FORMAT=<ID=GT,Number=1,Type=String,Description=Genotype>
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=Genotype quality>
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description=Phred scaled relative Likelihoods of the genotypes>
+##FORMAT=<ID=AF,Number=2,Type=Float,Description=Arbitrary float field with 2 values (test purposes only)>
+##FORMAT=<ID=AS,Number=1,Type=String,Description=Arbitrary string field with 2 values (test purposes only)>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878	NA12891	NA12892
+1	10000000	.	T	C	80	PASS	AF=0.5;AN=6;VALIDATED;DESC=Test1,Test2	GT:GQ:PL:AF:AS	0/1:35:10,0,100:3.1,2.2:ABA	0/0:35:0,10,1000:3.1,2.2:ABA	1/1:35:10,100,0:3.1,2.2:ABA
+20	10001000	.	GG	AA	8.4	PASS	AF=0.5;AN=6	GT:GQ:PL:AF:AS	0/1:35:10,0,100:3.1,2.2:ABA	0/0:35:0,10,100:3.1,2.2:ABA	1/1:35:10,100,0:3.1,2.2:ABA
+20	10002000	.	TAGTGQA	T	.	LOW_QUAL	AF=0.5;AN=6	GT:GQ:PL:AF:AS	0/1:35:10,0,100:3.1,2.2:ABA	0/0:35:0,10,2000000000:3.1,2.2:ABA	1/1:35:10,100,0:3.1,2.2:ABA
+20	10003000	.	A	AGCT	.	NOT_DEFINED	AF=0.5;AN=6	GT:GQ:PL:AF:AS	0/1:35:10,0,100:3.1,2.2:ABA	0/0:35:0,10,100:3.1,2.2:ABA	1/1:35:10,100,0:3.1,2.2:ABA
+22	10004000	.	GAT	G,GATAT	.	PASS;MISSED	AF=0.5,0;AN=6	GT:GQ:PL:AF:AS	0/1:35:10,0,100,2,4,8:3.1,2.2:ABA	0/0:35:0,10,100,2,4,8:3.1,2.2:ABA	1/1:35:10,100,0,2,4,8:3.1,2.2:ABA

--- a/testdata/missing_header.vcf
+++ b/testdata/missing_header.vcf
@@ -1,0 +1,21 @@
+##fileformat=VCFv4.1
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=VALIDATED,Number=0,Type=Flag,Description="Validated By Follow-up Experiment">
+##INFO=<ID=DESC,Number=.,Type=String,Description="Custom Description">
+##FILTER=<ID=PASS,Description=All filters passed>
+##FILTER=<ID=LOW_QUAL,Description=Low quality call>
+##FILTER=<ID=MISSED,Description=Missed by the variant caller>
+##FILTER=<ID=NOT_DEFINED,Description=Undefined filter>
+##contig=<ID=20,Length=64000000>
+##contig=<ID=22,Length=120000000>
+##FORMAT=<ID=GT,Number=1,Type=String,Description=Genotype>
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=Genotype quality>
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description=Phred scaled relative Likelihoods of the genotypes>
+##FORMAT=<ID=AF,Number=2,Type=Float,Description=Arbitrary float field with 2 values (test purposes only)>
+##FORMAT=<ID=AS,Number=1,Type=String,Description=Arbitrary string field with 2 values (test purposes only)>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878	NA12891	NA12892
+20	10001000	.	GG	AA	8.4	PASS	AF=0.5;AN=6	GT:GQ:PL:AF:AS	0/1:35:10,0,100:3.1,2.2:ABA	0/0:35:0,10,100:3.1,2.2:ABA	1/1:35:10,100,0:3.1,2.2:ABA
+20	10002000	.	TAGTGQA	T	.	LOW_QUAL	AF=0.5;AN=6	GT:GQ:PL:AF:AS	0/1:35:10,0,100:3.1,2.2:ABA	0/0:35:0,10,2000000000:3.1,2.2:ABA	1/1:35:10,100,0:3.1,2.2:ABA
+20	10003000	.	A	AGCT	.	NOT_DEFINED	AF=0.5;AN=6	GT:GQ:PL:AF:AS	0/1:35:10,0,100:3.1,2.2:ABA	0/0:35:0,10,100:3.1,2.2:ABA	1/1:35:10,100,0:3.1,2.2:ABA
+22	10004000	.	GAT	G,GATAT	.	PASS;MISSED	AF=0.5,0;AN=6	GT:GQ:PL:AF:AS	0/1:35:10,0,100,2,4,8:3.1,2.2:ABA	0/0:35:0,10,100,2,4,8:3.1,2.2:ABA	1/1:35:10,100,0,2,4,8:3.1,2.2:ABA


### PR DESCRIPTION
Enables iteration over multiple input files, returning a vector of Variant objects per genomic location.

The vector is reused per location, so the caller must complete processing before continuing iteration, or make a copy.

Strongly inspired by the example of VariantReader/VariantIterator.  Merging these Readers or Iterators may be appropriate.

This is an alternative solution to Issue #76 
