### PR TITLE
Utils: add a zip iterator variadic template

### DIFF
--- a/gamgee/utils/utils.cpp
+++ b/gamgee/utils/utils.cpp
@@ -50,11 +50,6 @@ std::string reverse_complement(const std::string& sequence) {
   return rev;
 }
 
-template<typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args) { 
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...)); 
-}
-
 std::vector<std::string> hts_string_array_to_vector(const char * const * const string_array, const uint32_t array_size) {
   auto result = std::vector<std::string>{};
   result.reserve(array_size);

--- a/gamgee/utils/utils.h
+++ b/gamgee/utils/utils.h
@@ -1,6 +1,9 @@
 #ifndef __gamgee_utils__
 #define __gamgee_utils__
 
+#include <boost/iterator/zip_iterator.hpp>
+#include <boost/range.hpp>
+
 #include <string>
 #include <memory>
 #include <vector>
@@ -45,13 +48,6 @@ std::string complement(std::string& sequence);
 char complement (const char base);
 
 /**
- * @brief herb sutter's implementation of make unique
- * @note this is going to become standard in C++14, we can drop this as soon as gcc 4.9 and clang 3.5 are released
- */
-template<typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args);
-
-/**
  * @brief converts an array of c-strings into a vector<string>
  * 
  * Useful in many hts structs where a list of names is stored as a char** and we want to 
@@ -87,6 +83,28 @@ inline void check_max_boundary(const uint32_t index, const uint32_t max_index) {
     error_message << "The index requested is out of range: " << index << " the maximum index is " << max_index << std::endl;
     throw std::out_of_range(error_message.str());
   }
+}
+
+/**
+ * @brief utility method to zip iterators together with simpler syntax than boost
+ *
+ * This is a wrapper over boost's zip_iterator interface to simplify the usage of zip
+ * iterators especially in for each loops. This function enables the following syntax:
+ * 
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * for (const auto tup : zip(a, b, c, d) {
+ *   ... // use tup values as a boost::tuple
+ * }
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * for more details look at boost's zip_iterator documentation.
+ */
+template <typename... T>
+auto zip(const T&... containers) -> boost::iterator_range<boost::zip_iterator<decltype(boost::make_tuple(std::begin(containers)...))>>
+{
+    auto zip_begin = boost::make_zip_iterator(boost::make_tuple(std::begin(containers)...));
+    auto zip_end = boost::make_zip_iterator(boost::make_tuple(std::end(containers)...));
+    return boost::make_iterator_range(zip_begin, zip_end);
 }
 
 

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -28,3 +28,39 @@ BOOST_AUTO_TEST_CASE( sequence_utils_complement_test )
   BOOST_CHECK_EQUAL(complement("AAAAAAAAAAAA"), "TTTTTTTTTTTT");                     
   BOOST_CHECK_EQUAL(complement("G"), "C");                     
 }
+
+BOOST_AUTO_TEST_CASE( zip_iterators_test ) {
+  const auto v_odd = std::vector<uint32_t>{1, 3, 5, 7};
+  const auto v_even = std::vector<uint32_t>{2, 4, 6, 8};
+  const auto v_alpha = std::vector<char>{'A', 'B', 'C', 'D'};
+
+  // simple test with two vectors of the same type
+  auto i = 0u;
+  for (const auto tup : zip(v_odd, v_even)) {
+    BOOST_CHECK_EQUAL(tup.get<0>(), v_odd[i]);
+    BOOST_CHECK_EQUAL(tup.get<1>(), v_even[i]);
+    ++i;
+  }
+
+  // testing different types
+  auto j = 0u;
+  for (const auto tup : zip(v_odd, v_even, v_alpha)) {
+    BOOST_CHECK_EQUAL(tup.get<0>(), v_odd[j]);
+    BOOST_CHECK_EQUAL(tup.get<1>(), v_even[j]);
+    BOOST_CHECK_EQUAL(tup.get<2>(), v_alpha[j]);
+    ++j;
+  }
+
+  // testing boost::tie
+  auto k = 0u;
+  for (const auto tup : zip(v_odd, v_even, v_alpha)) {
+    auto odd = 0u;
+    auto even = 0u;
+    auto alpha = 'Z';
+    boost::tie(odd, even, alpha) = tup;
+    BOOST_CHECK_EQUAL(odd, v_odd[k]);
+    BOOST_CHECK_EQUAL(even, v_even[k]);
+    BOOST_CHECK_EQUAL(alpha, v_alpha[k]);
+    ++k;
+  }
+}


### PR DESCRIPTION
To facilitate the use of boost::zip_iterators in gamgee and foghorn. This can
be very useful especially when dealing with multiple streams that need to be
iterated in sync. In some cases it makes the code more readable too.
