### PR TITLE
Move every boundary check to max_boundary check to avoid unnecessary checks

### DIFF
--- a/gamgee/base_quals.cpp
+++ b/gamgee/base_quals.cpp
@@ -77,7 +77,7 @@ BaseQuals& BaseQuals::operator=(BaseQuals&& other) noexcept {
   * @return base quality at the specified index as an unsigned byte
   */
 uint8_t BaseQuals::operator[](const uint32_t index) const {
-  utils::check_max_boundary(index, m_num_quals-1);
+  utils::check_max_boundary(index, m_num_quals);
   return m_quals[index];
 }
 
@@ -87,7 +87,7 @@ uint8_t BaseQuals::operator[](const uint32_t index) const {
  * @return base quality at the specified index as an unsigned byte
  */
 uint8_t& BaseQuals::operator[](const uint32_t index) {
-  utils::check_max_boundary(index, m_num_quals-1);
+  utils::check_max_boundary(index, m_num_quals);
   return m_quals[index];
 }
 

--- a/gamgee/utils/utils.h
+++ b/gamgee/utils/utils.h
@@ -56,31 +56,15 @@ char complement (const char base);
 std::vector<std::string> hts_string_array_to_vector(const char * const * const string_array, const uint32_t array_size);
 
 /**
- * @brief checks that an index is within min_index to max_index
- * @param index the index to check
- * @param max_index the maximum valid index
- * @param min_index the minimum valid index (typically 0 for array boundaries, but can be arbitrary for pointer checks)
+ * @brief checks that an index is greater than or equal to size
+ * @param index the index between 0 and size to check
+ * @param size one past the maximum valid index
  * @exception throws an out_of_bounds exception if index is out of limits
  */
-inline void check_boundaries(const int index, const int max_index, const int min_index = 0) {
-  if (index < min_index || index > max_index) {
+inline void check_max_boundary(const uint32_t index, const uint32_t size) {
+  if (index >= size) {
     std::stringstream error_message {};  ///< @todo update this to auto when gcc-4.9 is available on travis-ci
-    error_message << "The index requested is out of range: " << index << " the maximum index is " << max_index << " and the minimum is " << min_index << std::endl;
-    throw std::out_of_range(error_message.str());
-  }
-}
-
-
-/**
- * @brief checks that an index is greater than max_index
- * @param index the index to check
- * @param max_index the maximum valid index
- * @exception throws an out_of_bounds exception if index is out of limits
- */
-inline void check_max_boundary(const uint32_t index, const uint32_t max_index) {
-  if (index > max_index) {
-    std::stringstream error_message {};  ///< @todo update this to auto when gcc-4.9 is available on travis-ci
-    error_message << "The index requested is out of range: " << index << " the maximum index is " << max_index << std::endl;
+    error_message << "Index:  " << index << " must be less than " << size << std::endl;
     throw std::out_of_range(error_message.str());
   }
 }

--- a/gamgee/variant_field.h
+++ b/gamgee/variant_field.h
@@ -123,7 +123,7 @@ class VariantField {
    * @return the value if it is a basic type (e.g. GQ, GL), or a specific object if it is a complex type (e.g. PL, AD,...)
    */
   TYPE operator[](const uint32_t sample) const {
-    utils::check_boundaries(sample, m_body->n_sample-1);
+    utils::check_max_boundary(sample, m_body->n_sample);
     return TYPE{m_body, m_format_ptr, m_format_ptr->p + (sample * m_format_ptr->size)}; 
   }
 

--- a/gamgee/variant_field_iterator.h
+++ b/gamgee/variant_field_iterator.h
@@ -216,7 +216,7 @@ class VariantFieldIterator : public std::iterator<std::random_access_iterator_ta
    * @return the value if it is a basic type (e.g. GQ, GL), or a specific object if it is a complex type (e.g. PL, AD,...)
    */
   TYPE operator[](const uint32_t sample) const {
-    utils::check_boundaries(sample, m_body->n_sample);
+    utils::check_max_boundary(sample, m_body->n_sample);
     return TYPE{m_body, m_format_ptr, m_format_ptr->p + (sample * m_body->n_sample)};
   }
 

--- a/gamgee/variant_field_value.h
+++ b/gamgee/variant_field_value.h
@@ -110,7 +110,7 @@ class VariantFieldValue {
    * @return the value in that index
    */
   VALUE_TYPE operator[](const uint32_t index) const {
-    utils::check_boundaries(index, m_format_ptr->n - 1);
+    utils::check_max_boundary(index, m_format_ptr->n);
     return convert_from_byte_array(index); 
   }
 


### PR DESCRIPTION
Since @droazen forced me to change utils::check_boundaries to a version that takes in unsigned ints and doesn't check for the lower boundary, it was only reasonable to go around the code and replace all usages that were wastefully checking for lower boundaries and use the new function. 

Also, since every single use was passing the index past the limit, I changed the function signature to reflect the most common use case.
