### PR TITLE
When deep copying Sam/Variant records, do not also deep copy the header

### DIFF
--- a/gamgee/sam.cpp
+++ b/gamgee/sam.cpp
@@ -25,9 +25,12 @@ Sam::Sam(const std::shared_ptr<bam_hdr_t>& header, const std::shared_ptr<bam1_t>
  * @note the copy will have exclusive ownership over the newly-allocated htslib memory
  *       until a data field (cigar, bases, etc.) is accessed, after which it will be
  *       shared via reference counting with the Cigar, etc. objects
+ * @note does not perform a deep copy of the sam header; to copy the header,
+ *       first get it via the header() function and then copy it via the usual C++
+ *       semantics
  */
 Sam::Sam(const Sam& other) :
-  m_header { utils::make_shared_sam_header(utils::sam_header_deep_copy(other.m_header.get())) },
+  m_header { other.m_header },
   m_body { utils::make_shared_sam(utils::sam_deep_copy(other.m_body.get())) }
 {}
 
@@ -45,12 +48,15 @@ Sam::Sam(Sam&& other) noexcept :
  * @note the copy will have exclusive ownership over the newly-allocated htslib memory
  *       until a data field (cigar, bases, etc.) is accessed, after which it will be
  *       shared via reference counting with the Cigar, etc. objects
+ * @note does not perform a deep copy of the sam header; to copy the header,
+ *       first get it via the header() function and then copy it via the usual C++
+ *       semantics
  */
 Sam& Sam::operator=(const Sam& other) {
   if ( &other == this )  
     return *this;
-  m_header = utils::make_shared_sam_header(utils::sam_header_deep_copy(other.m_header.get())); ///< shared_ptr assignment will take care of deallocating old sam record if necessary
-  m_body = utils::make_shared_sam(utils::sam_deep_copy(other.m_body.get()));                   ///< shared_ptr assignment will take care of deallocating old sam record if necessary
+  m_header = other.m_header;      ///< shared_ptr assignment will take care of deallocating old sam record if necessary
+  m_body = utils::make_shared_sam(utils::sam_deep_copy(other.m_body.get()));     ///< shared_ptr assignment will take care of deallocating old sam record if necessary
   return *this;
 }
 

--- a/gamgee/variant.cpp
+++ b/gamgee/variant.cpp
@@ -19,10 +19,14 @@ Variant::Variant(const std::shared_ptr<bcf_hdr_t>& header, const std::shared_ptr
 {}
 
 /**
- * @brief creates a deep copy of a variant record and header
+ * @brief creates a deep copy of a variant record
+ *
+ * @note does not perform a deep copy of the variant header; to copy the header,
+ *       first get it via the header() function and then copy it via the usual C++
+ *       semantics
  */
 Variant::Variant(const Variant& other) :
-  m_header {utils::make_shared_variant_header(utils::variant_header_deep_copy(other.m_header.get()))},
+  m_header {other.m_header},
   m_body {utils::make_shared_variant(utils::variant_deep_copy(other.m_body.get()))}
 {}
 
@@ -37,13 +41,15 @@ Variant::Variant(Variant&& other) noexcept :
 /**
  * @brief creates a deep copy of a variant record
  * @param other the Variant to be copied
- * @note the parameter is passed by copy so we can maintain the strong exception safety guarantee
+ * @note does not perform a deep copy of the variant header; to copy the header,
+ *       first get it via the header() function and then copy it via the usual C++
+ *       semantics
  */
 Variant& Variant::operator=(const Variant& other) {
   if ( &other == this )  
     return *this;
-  m_body = utils::make_shared_variant(utils::variant_deep_copy(other.m_body.get()));                   ///< shared_ptr assignment will take care of deallocating old record if necessary
-  m_header = utils::make_shared_variant_header(utils::variant_header_deep_copy(other.m_header.get())); ///< shared_ptr assignment will take care of deallocating old record if necessary
+  m_header = other.m_header;    ///< shared_ptr assignment will take care of deallocating old record if necessary
+  m_body = utils::make_shared_variant(utils::variant_deep_copy(other.m_body.get()));  ///< shared_ptr assignment will take care of deallocating old record if necessary
   return *this;
 }
 


### PR DESCRIPTION
Deep copying the headers every time a record is copied is wasteful and
unnecessary, given that headers are immutable (with the single exception
of VariantHeader::advanced_merge_header(), which should be moved to a
builder)
