### PR TITLE
Normalize all include guards

### DIFF
--- a/gamgee/base_quals.h
+++ b/gamgee/base_quals.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__base_quals__
-#define __gamgee__base_quals__
+#ifndef gamgee__base_quals__guard
+#define gamgee__base_quals__guard
 
 #include "htslib/sam.h"
 
@@ -36,4 +36,4 @@ class BaseQuals {
 
 }
 
-#endif /* __gamgee__base_quals__ */
+#endif /* gamgee__base_quals__guard */

--- a/gamgee/cigar.h
+++ b/gamgee/cigar.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__cigar__
-#define __gamgee__cigar__
+#ifndef gamgee__cigar__guard
+#define gamgee__cigar__guard
 
 #include "htslib/sam.h"
 
@@ -69,4 +69,4 @@ class Cigar {
 
 }
 
-#endif /* __gamgee__cigar__ */
+#endif /* gamgee__cigar__guard */

--- a/gamgee/fastq.h
+++ b/gamgee/fastq.h
@@ -1,5 +1,5 @@
-#ifndef __foghorn__fastq__
-#define __foghorn__fastq__
+#ifndef gamgee__fastq__guard
+#define gamgee__fastq__guard
 
 #include <string>
 
@@ -72,4 +72,4 @@ class Fastq {
 */
 std::ostream& operator<< (std::ostream& os, const gamgee::Fastq& fq);
 
-#endif /* defined(__foghorn__fastq__) */
+#endif // gamgee__fastq__guard 

--- a/gamgee/fastq_iterator.h
+++ b/gamgee/fastq_iterator.h
@@ -1,5 +1,5 @@
-#ifndef __foghorn__fastq_iterator__
-#define __foghorn__fastq_iterator__
+#ifndef gamgee__fastq_iterator__guard
+#define gamgee__fastq_iterator__guard
 
 
 #include "fastq.h"
@@ -76,4 +76,4 @@ class FastqIterator {
 
 }  // end namespace gamgee
 
-#endif
+#endif // gamgee__fastq_iterator__guard

--- a/gamgee/fastq_reader.h
+++ b/gamgee/fastq_reader.h
@@ -1,5 +1,5 @@
-#ifndef __foghorn__fastq_reader__
-#define __foghorn__fastq_reader__
+#ifndef gamgee__fastq_reader__guard
+#define gamgee__fastq_reader__guard
 
 #include "fastq_iterator.h"
 
@@ -88,4 +88,4 @@ private:
 
 }  // end of namespace
 
-#endif /* defined(__foghorn__fastq_iterator__) */
+#endif // gamgee__fastq_reader__guard

--- a/gamgee/gamgee.h
+++ b/gamgee/gamgee.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__gamgee__
-#define __gamgee__gamgee__
+#ifndef gamgee__gamgee__guard
+#define gamgee__gamgee__guard
 
 #include "sam.h"
 #include "sam_reader.h"
@@ -16,4 +16,4 @@
 
 #include "is_missing.h"
 
-#endif  /* __gamgee__gamgee__ */
+#endif  /* gamgee__gamgee__guard */

--- a/gamgee/is_missing.h
+++ b/gamgee/is_missing.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__is_missing__
-#define __gamgee__is_missing__
+#ifndef gamgee__is_missing__guard
+#define gamgee__is_missing__guard
 
 #include "sam_tag.h"
 
@@ -14,4 +14,4 @@ bool is_missing(const SamTag<T>& tag) { return !tag.is_present(); } ///< @brief 
 
 }
 
-#endif
+#endif // gamgee__is_missing__guard

--- a/gamgee/multiple_variant_iterator.h
+++ b/gamgee/multiple_variant_iterator.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__multiple_variant_iterator__
-#define __gamgee__multiple_variant_iterator__
+#ifndef gamgee__multiple_variant_iterator__guard
+#define gamgee__multiple_variant_iterator__guard
 
 #include "htslib/vcf.h"
 
@@ -80,4 +80,4 @@ class MultipleVariantIterator {
 
 }  // end namespace gamgee
 
-#endif	// __gamgee__multiple_variant_iterator__
+#endif	// gamgee__multiple_variant_iterator__guard

--- a/gamgee/multiple_variant_reader.h
+++ b/gamgee/multiple_variant_reader.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__multiple_variant_reader__
-#define __gamgee__multiple_variant_reader__
+#ifndef gamgee__multiple_variant_reader__guard
+#define gamgee__multiple_variant_reader__guard
 
 #include "htslib/vcf.h"
 
@@ -119,4 +119,4 @@ class MultipleVariantReader {
 
 }  // end namespace gamgee
 
-#endif /* defined(__gamgee__multiple_variant_reader__) */
+#endif /* defined(gamgee__multiple_variant_reader__guard) */

--- a/gamgee/read_bases.h
+++ b/gamgee/read_bases.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__read_bases__
-#define __gamgee__read_bases__
+#ifndef gamgee__read_bases__guard
+#define gamgee__read_bases__guard
 
 #include "htslib/sam.h"
 
@@ -51,4 +51,4 @@ private:
 
 }
 
-#endif /* __gamgee__read_bases__ */
+#endif /* gamgee__read_bases__guard */

--- a/gamgee/sam.h
+++ b/gamgee/sam.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__sam__
-#define __gamgee__sam__
+#ifndef gamgee__sam__guard
+#define gamgee__sam__guard
 
 #include "sam_header.h"
 #include "read_bases.h"
@@ -109,4 +109,4 @@ class Sam {
 
 }  // end of namespace
 
-#endif /* defined(__gamgee__sam__) */
+#endif /* defined(gamgee__sam__guard) */

--- a/gamgee/sam_builder.h
+++ b/gamgee/sam_builder.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__sam_builder__
-#define __gamgee__sam_builder__
+#ifndef gamgee__sam_builder__guard
+#define gamgee__sam_builder__guard
 
 #include "sam.h"
 #include "sam_builder_data_field.h"
@@ -135,4 +135,4 @@ class SamBuilder {
 }
 
 
-#endif /* __gamgee__sam_builder__ */
+#endif /* gamgee__sam_builder__guard */

--- a/gamgee/sam_builder_data_field.h
+++ b/gamgee/sam_builder_data_field.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__sam_builder_data_field__
-#define __gamgee__sam_builder_data_field__
+#ifndef gamgee__sam_builder_data_field__guard
+#define gamgee__sam_builder_data_field__guard
 
 #include <memory>
 
@@ -46,4 +46,4 @@ class SamBuilderDataField {
 
 }
 
-#endif /* __gamgee__sam_builder_data_field__ */
+#endif /* gamgee__sam_builder_data_field__guard */

--- a/gamgee/sam_header.h
+++ b/gamgee/sam_header.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__sam_header__
-#define __gamgee__sam_header__
+#ifndef gamgee__sam_header__guard
+#define gamgee__sam_header__guard
 
 #include "htslib/sam.h"
 
@@ -31,4 +31,4 @@ class SamHeader {
 };
 
 }
-#endif 
+#endif // gamgee__sam_header__guard

--- a/gamgee/sam_iterator.h
+++ b/gamgee/sam_iterator.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__sam_iterator__
-#define __gamgee__sam_iterator__
+#ifndef gamgee__sam_iterator__guard
+#define gamgee__sam_iterator__guard
 
 #include "sam.h"
 
@@ -69,4 +69,4 @@ class SamIterator {
 
 }  // end namespace gamgee
 
-#endif
+#endif // gamgee__sam_iterator__guard

--- a/gamgee/sam_pair_iterator.h
+++ b/gamgee/sam_pair_iterator.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__sam_pair_iterator__
-#define __gamgee__sam_pair_iterator__
+#ifndef gamgee__sam_pair_iterator__guard
+#define gamgee__sam_pair_iterator__guard
 
 #include "sam.h"
 
@@ -79,4 +79,4 @@ class SamPairIterator {
 
 }  // end namespace gamgee
 
-#endif
+#endif // gamgee__sam_pair_iterator__guard

--- a/gamgee/sam_reader.h
+++ b/gamgee/sam_reader.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__sam_reader__
-#define __gamgee__sam_reader__
+#ifndef gamgee__sam_reader__guard
+#define gamgee__sam_reader__guard
 
 #include "sam_iterator.h"
 #include "sam_pair_iterator.h"
@@ -103,4 +103,4 @@ using PairSamReader = SamReader<SamPairIterator>;
 
 }  // end of namespace
 
-#endif /* defined(__gamgee__sam_reader__) */
+#endif /* defined(gamgee__sam_reader__guard) */

--- a/gamgee/sam_tag.h
+++ b/gamgee/sam_tag.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__sam_tag__
-#define __gamgee__sam_tag__
+#ifndef gamgee__sam_tag__guard
+#define gamgee__sam_tag__guard
 
 #include <string>
 
@@ -55,4 +55,4 @@ class SamTag {
 
 }
 
-#endif // __gamgee__sam_tag__
+#endif // gamgee__sam_tag__guard

--- a/gamgee/sam_writer.h
+++ b/gamgee/sam_writer.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee_sam_writer__
-#define __gamgee_sam_writer__
+#ifndef gamgee__sam_writer__guard
+#define gamgee__sam_writer__guard
 
 #include <string>
 
@@ -62,4 +62,5 @@ class SamWriter {
 };
 
 }
-#endif 
+
+#endif // gamgee__sam_writer__guard

--- a/gamgee/utils/format_field_type.h
+++ b/gamgee/utils/format_field_type.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_field_utils__
-#define __gamgee__variant_field_utils__
+#ifndef gamgee__format_field_type__guard
+#define gamgee__format_field_type__guard
 
 #include <string>
 #include <stdexcept>
@@ -115,4 +115,4 @@ inline uint8_t size_for_type(const FormatFieldType& type) {
 } // end namespace utils
 } // end namespace gamgee
 
-#endif
+#endif // gamgee__format_field_type__guard

--- a/gamgee/utils/hts_memory.h
+++ b/gamgee/utils/hts_memory.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee_hts_memory__
-#define __gamgee_hts_memory__
+#ifndef gamgee__hts_memory__guard
+#define gamgee__hts_memory__guard
 
 #include "htslib/sam.h"
 #include "htslib/vcf.h"
@@ -71,4 +71,4 @@ std::string htslib_filter_name(bcf_hdr_t* header, bcf1_t* body, int index);
 }
 }
 
-#endif
+#endif // gamgee__hts_memory__guard

--- a/gamgee/utils/utils.h
+++ b/gamgee/utils/utils.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee_utils__
-#define __gamgee_utils__
+#ifndef gamgee__utils__guard
+#define gamgee__utils__guard
 
 #include <boost/iterator/zip_iterator.hpp>
 #include <boost/range.hpp>
@@ -95,4 +95,4 @@ auto zip(const T&... containers) -> boost::iterator_range<boost::zip_iterator<de
 } // end utils namespace
 } // end gamgee namespace
 
-#endif
+#endif // gamgee__utils__guard

--- a/gamgee/variant.h
+++ b/gamgee/variant.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant__
-#define __gamgee__variant__
+#ifndef gamgee__variant__guard
+#define gamgee__variant__guard
 
 #include "variant_header.h"
 #include "variant_field.h"
@@ -97,4 +97,4 @@ class Variant {
 
 }  // end of namespace
 
-#endif /* defined(__gamgee__variant__) */
+#endif /* defined(gamgee__variant__guard) */

--- a/gamgee/variant_field.h
+++ b/gamgee/variant_field.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_field__
-#define __gamgee__variant_field__
+#ifndef gamgee__variant_field__guard
+#define gamgee__variant_field__guard
 
 #include <iostream>
 
@@ -153,4 +153,4 @@ class VariantField {
 
 }
 
-#endif
+#endif // gamgee__variant_field__guard

--- a/gamgee/variant_field_iterator.h
+++ b/gamgee/variant_field_iterator.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_field_iterator__
-#define __gamgee__variant_field_iterator__ 
+#ifndef gamgee__variant_field_iterator__guard
+#define gamgee__variant_field_iterator__guard 
 
 #include "utils/utils.h"
 
@@ -239,4 +239,4 @@ class VariantFieldIterator : public std::iterator<std::random_access_iterator_ta
 
 }
 
-#endif
+#endif // gamgee__variant_field_iterator__guard

--- a/gamgee/variant_field_value.h
+++ b/gamgee/variant_field_value.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_field_value__
-#define __gamgee__variant_field_value__
+#ifndef gamgee__variant_field_value__guard
+#define gamgee__variant_field_value__guard
 
 #include "variant_field_value_iterator.h"
 #include "utils/hts_memory.h"

--- a/gamgee/variant_field_value_iterator.h
+++ b/gamgee/variant_field_value_iterator.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_field_value_iterator__
-#define __gamgee__variant_field_value_iterator__
+#ifndef gamgee__variant_field_value_iterator__guard
+#define gamgee__variant_field_value_iterator__guard
 
 #include "utils/format_field_type.h"
 
@@ -233,4 +233,4 @@ std::string VariantFieldValueIterator<std::string>::convert_from_byte_array(cons
 
 };
 
-#endif
+#endif // gamgee__variant_field_value_iterator__guard

--- a/gamgee/variant_filters.h
+++ b/gamgee/variant_filters.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_filters__
-#define __gamgee__variant_filters__
+#ifndef gamgee__variant_filters__guard
+#define gamgee__variant_filters__guard
 
 #include "variant_filters_iterator.h"
 #include "utils/hts_memory.h"
@@ -58,4 +58,4 @@ class VariantFilters {
 
 }
 
-#endif
+#endif // gamgee__variant_filters__guard

--- a/gamgee/variant_filters_iterator.h
+++ b/gamgee/variant_filters_iterator.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_filters_iterator__
-#define __gamgee__variant_filters_iterator__
+#ifndef gamgee__variant_filters_iterator__guard
+#define gamgee__variant_filters_iterator__guard
 
 #include "variant_filters.h"
 #include "utils/hts_memory.h"
@@ -51,4 +51,4 @@ class VariantFiltersIterator : public std::iterator<std::random_access_iterator_
 
 }
 
-#endif
+#endif // gamgee__variant_filters_iterator__guard

--- a/gamgee/variant_header.h
+++ b/gamgee/variant_header.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_header__
-#define __gamgee__variant_header__
+#ifndef gamgee__variant_header__guard
+#define gamgee__variant_header__guard
 
 #include "htslib/vcf.h"
 
@@ -48,4 +48,4 @@ class VariantHeader {
 
 }
 
-#endif
+#endif // gamgee__variant_header__guard

--- a/gamgee/variant_header_builder.h
+++ b/gamgee/variant_header_builder.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_header_builder__
-#define __gamgee__variant_header_builder__
+#ifndef gamgee__variant_header_builder__guard
+#define gamgee__variant_header_builder__guard
 
 #include "utils/utils.h"
 #include "variant_header.h"
@@ -43,4 +43,4 @@ class VariantHeaderBuilder {
 
 }
 
-#endif
+#endif // gamgee__variant_header_builder__guard

--- a/gamgee/variant_iterator.h
+++ b/gamgee/variant_iterator.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_iterator__
-#define __gamgee__variant_iterator__
+#ifndef gamgee__variant_iterator__guard
+#define gamgee__variant_iterator__guard
 
 #include "variant.h"
 
@@ -76,4 +76,4 @@ class VariantIterator {
 
 }  // end namespace gamgee
 
-#endif
+#endif // gamgee__variant_iterator__guard

--- a/gamgee/variant_reader.h
+++ b/gamgee/variant_reader.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee__variant_reader__
-#define __gamgee__variant_reader__
+#ifndef gamgee__variant_reader__guard
+#define gamgee__variant_reader__guard
 
 #include "variant_header.h"
 #include "variant_iterator.h"
@@ -136,4 +136,4 @@ using SingleVariantReader = VariantReader<VariantIterator>;
 
 }  // end of namespace
 
-#endif /* defined(__gamgee__variant_reader__) */
+#endif /* defined(gamgee__variant_reader__guard) */

--- a/gamgee/variant_writer.h
+++ b/gamgee/variant_writer.h
@@ -1,5 +1,5 @@
-#ifndef __gamgee_variant_writer__
-#define __gamgee_variant_writer__
+#ifndef gamgee__variant_writer__guard
+#define gamgee__variant_writer__guard
 
 #include <string>
 
@@ -62,4 +62,5 @@ class VariantWriter {
 };
 
 }
-#endif 
+
+#endif // gamgee__variant_writer__guard


### PR DESCRIPTION
all include guards are now of the format :

`gamgee__file_name__guard`

fixes #130
