### PR TITLE
Jamroot: make release the default build

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -3,6 +3,8 @@ project gamgee
         <cxxflags>-std=c++1y
         <linkflags>-std=c++1y
         <warnings-as-errors>on
+    : default-build
+        <variant>release
   ;
 
   use-project /gamgee/libs : lib ;
@@ -10,6 +12,6 @@ project gamgee
   lib gamgee 
     : [ glob-tree *.cpp : .git test lib bin dox build ] /gamgee/libs//hts
     : <link>static 
-    :
+    : 
     : <include>.
   ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -4,5 +4,5 @@ lib boost_unit_test_framework ;
 run [ glob *.cpp ] /gamgee//gamgee /gamgee/libs//hts boost_unit_test_framework 
     : 
     : 
-    : <define>BOOST_ALL_DYN_LINK <threading>multi <include>../gamgee
+    : <define>BOOST_ALL_DYN_LINK <threading>multi <include>../gamgee <variant>debug
     : run ;


### PR DESCRIPTION
- `b2` will now build the release variant, unless you specify `b2 debug` in the command line.
- `b2 test` will still build the debug variant by default, unless you specify `b2 test release` (but why would you do that?)

fixes #128
