### PR TITLE
SamHeader: add n_sequences member function

### DIFF
--- a/gamgee/sam_header.cpp
+++ b/gamgee/sam_header.cpp
@@ -53,7 +53,7 @@ namespace gamgee {
    * @brief Returns the length of the given sequence as stored in the @SQ tag in the BAM header, or 0 if the sequence
    * name is not found.
    */
-  uint32_t SamHeader::sequence_length(const std::string& sequence_name)  {
+  uint32_t SamHeader::sequence_length(const std::string& sequence_name) const {
 	  auto c = sequence_name.c_str();
 	  for (int i = 0; i < m_header->n_targets; i++) {
 		  if (strcmp(c,m_header->target_name[i]) == 0) {
@@ -61,16 +61,6 @@ namespace gamgee {
 		  }
 	  }
 	  return 0;
-  }
-
-  ///< @brief Returns the length of the given sequence as stored in the @SQ tag in the BAM header.
-  uint32_t SamHeader::sequence_length(const uint32_t sequence_index) {
-	  return m_header->target_len[sequence_index];
-  }
-
-  ///< @brief Returns the sequence name for the sequence with the given zero-based index
-  std::string SamHeader::sequence_name(const uint32_t sequence_index) {
-	  return std::string(m_header->target_name[sequence_index]);
   }
 
 }

--- a/gamgee/sam_header.h
+++ b/gamgee/sam_header.h
@@ -13,15 +13,16 @@ namespace gamgee {
  */
 class SamHeader {
  public:
-  explicit SamHeader() = default;                               ///< @brief initializes a null SamHeader @warning if you need to create a SamHeader from scratch, use the builder instead
-  explicit SamHeader(const std::shared_ptr<bam_hdr_t>& header); ///< @brief creates a SamHeader given htslib object. @note used by all iterators
-  SamHeader(const SamHeader& other);                            ///< @brief makes a deep copy of a SamHeader. Shared pointers maintain state to all other associated objects correctly.
-  SamHeader(SamHeader&& other) noexcept;                        ///< @brief moves SamHeader accordingly. Shared pointers maintain state to all other associated objects correctly.
-  SamHeader& operator=(const SamHeader& other);                 ///< @brief deep copy assignment of a SamHeader. Shared pointers maintain state to all other associated objects correctly.
-  SamHeader& operator=(SamHeader&& other) noexcept;             ///< @brief move assignment of a SamHeader. Shared pointers maintain state to all other associated objects correctly.
-  uint32_t sequence_length(const std::string& sequence_name);   ///< @brief Returns the length of the given sequence as stored in the @SQ tag in the BAM header.
-  uint32_t sequence_length(const uint32_t sequence_index);      ///< @brief Returns the length of the given sequence as stored in the @SQ tag in the BAM header.
-  std::string sequence_name(const uint32_t sequence_index);	    ///< @brief Returns the sequence name for the sequence with the given zero-based index
+  explicit SamHeader() = default;                                   ///< @brief initializes a null SamHeader @warning if you need to create a SamHeader from scratch, use the builder instead
+  explicit SamHeader(const std::shared_ptr<bam_hdr_t>& header);     ///< @brief creates a SamHeader given htslib object. @note used by all iterators
+  SamHeader(const SamHeader& other);                                ///< @brief makes a deep copy of a SamHeader. Shared pointers maintain state to all other associated objects correctly.
+  SamHeader(SamHeader&& other) noexcept;                            ///< @brief moves SamHeader accordingly. Shared pointers maintain state to all other associated objects correctly.
+  SamHeader& operator=(const SamHeader& other);                     ///< @brief deep copy assignment of a SamHeader. Shared pointers maintain state to all other associated objects correctly.
+  SamHeader& operator=(SamHeader&& other) noexcept;                 ///< @brief move assignment of a SamHeader. Shared pointers maintain state to all other associated objects correctly.
+  uint32_t n_sequences() const {return m_header->n_targets;}        ///< @brief Returns the number of reference sequences in the header
+  uint32_t sequence_length(const std::string& sequence_name) const; ///< @brief Returns the length of the given reference sequence as stored in the @SQ tag in the BAM header.
+  uint32_t sequence_length(const uint32_t sequence_index) const { return m_header->target_len[sequence_index]; }                ///< @brief Returns the length of the given reference sequence as stored in the @SQ tag in the BAM header.
+  std::string sequence_name(const uint32_t sequence_index) const { return std::string(m_header->target_name[sequence_index]); } ///< @brief Returns the sequence name for the sequence with the given zero-based index
 
  private:
   std::shared_ptr<bam_hdr_t> m_header;

--- a/test/sam_header_test.cpp
+++ b/test/sam_header_test.cpp
@@ -9,11 +9,9 @@ BOOST_AUTO_TEST_CASE( sam_header )
 {
 	auto reader = SingleSamReader{"testdata/test_simple.bam"};
 	auto header = reader.header();
-
-	BOOST_CHECK_EQUAL("chr1", header.sequence_name(0));
-
-    BOOST_CHECK_EQUAL(100000, header.sequence_length("chr1"));
-    BOOST_CHECK_EQUAL(100000, header.sequence_length(0));
-
-    BOOST_CHECK_EQUAL(0, header.sequence_length("foo"));
+  BOOST_CHECK_EQUAL("chr1", header.sequence_name(0));
+  BOOST_CHECK_EQUAL(100000, header.sequence_length("chr1"));
+  BOOST_CHECK_EQUAL(100000, header.sequence_length(0));
+  BOOST_CHECK_EQUAL(0, header.sequence_length("foo"));
+  BOOST_CHECK_EQUAL(1, header.n_sequences());
 }


### PR DESCRIPTION
- add n_sequences member function to allow iteration over the reference sequences
- make const member functions const (they weren't for some reason)
- inline simple member functions
