### PR TITLE
Variant: rename format and info fields

### DIFF
--- a/gamgee/variant.h
+++ b/gamgee/variant.h
@@ -25,58 +25,50 @@ enum class DiploidPLGenotype { HOM_REF = 0, HET = 1, HOM_VAR = 2};
  */
 class Variant {
  public:
-  Variant() = default;                                                                                                ///< @brief initializes a null Variant @note this is only used internally by the iterators @warning if you need to create a Variant from scratch, use the builder instead
-  explicit Variant(const std::shared_ptr<bcf_hdr_t>& header, const std::shared_ptr<bcf1_t>& body) noexcept;           ///< @brief creates a Variant given htslib objects. @note used by all iterators
-  Variant(const Variant& other);                                                                                      ///< @brief makes a deep copy of a Variant and it's header. Shared pointers maintain state to all other associated objects correctly.
-  Variant(Variant&& other) noexcept;                                                                                  ///< @brief moves Variant and it's header accordingly. Shared pointers maintain state to all other associated objects correctly.
-  Variant& operator=(const Variant& other);                                                                           ///< @brief deep copy assignment of a Variant and it's header. Shared pointers maintain state to all other associated objects correctly.
-  Variant& operator=(Variant&& other) noexcept;                                                                       ///< @brief move assignment of a Variant and it's header. Shared pointers maintain state to all other associated objects correctly.
+  Variant() = default;                                                                                        ///< @brief initializes a null Variant @note this is only used internally by the iterators @warning if you need to create a Variant from scratch, use the builder instead
+  explicit Variant(const std::shared_ptr<bcf_hdr_t>& header, const std::shared_ptr<bcf1_t>& body) noexcept;   ///< @brief creates a Variant given htslib objects. @note used by all iterators
+  Variant(const Variant& other);                                                                              ///< @brief makes a deep copy of a Variant and it's header. Shared pointers maintain state to all other associated objects correctly.
+  Variant(Variant&& other) noexcept;                                                                          ///< @brief moves Variant and it's header accordingly. Shared pointers maintain state to all other associated objects correctly.
+  Variant& operator=(const Variant& other);                                                                   ///< @brief deep copy assignment of a Variant and it's header. Shared pointers maintain state to all other associated objects correctly.
+  Variant& operator=(Variant&& other) noexcept;                                                               ///< @brief move assignment of a Variant and it's header. Shared pointers maintain state to all other associated objects correctly.
 
   VariantHeader header() const { return VariantHeader{m_header}; }
 
-  uint32_t chromosome()      const {return uint32_t(m_body->rid);}                                                    ///< @brief returns the integer representation of the chromosome. Notice that chromosomes are listed in index order with regards to the header (so a 0-based number). Similar to Picards getReferenceIndex()
-  uint32_t alignment_start() const {return uint32_t(m_body->pos+1);}                                                  ///< @brief returns a 1-based alignment start position (as you would see in a VCF file). @note the internal encoding is 0-based to mimic that of the BCF files.
-  float    qual()            const {return m_body->qual;}                                                             ///< @brief returns the Phred scaled site qual (probability that the site is not reference). See VCF spec.
-  uint32_t n_samples()       const {return uint32_t(m_body->n_sample);}                                               ///< @brief returns the number of samples in this Variant record
-  uint32_t n_alleles()       const {return uint32_t(m_body->n_allele);}                                               ///< @brief returns the number of alleles in this Variant record
+  uint32_t chromosome()      const {return uint32_t(m_body->rid);}                                            ///< @brief returns the integer representation of the chromosome. Notice that chromosomes are listed in index order with regards to the header (so a 0-based number). Similar to Picards getReferenceIndex()
+  uint32_t alignment_start() const {return uint32_t(m_body->pos+1);}                                          ///< @brief returns a 1-based alignment start position (as you would see in a VCF file). @note the internal encoding is 0-based to mimic that of the BCF files.
+  float    qual()            const {return m_body->qual;}                                                     ///< @brief returns the Phred scaled site qual (probability that the site is not reference). See VCF spec.
+  uint32_t n_samples()       const {return uint32_t(m_body->n_sample);}                                       ///< @brief returns the number of samples in this Variant record
+  uint32_t n_alleles()       const {return uint32_t(m_body->n_allele);}                                       ///< @brief returns the number of alleles in this Variant record
 
-  std::string id() const;                                                                                             ///< @brief returns the variant id field (typically dbsnp id)
-  std::string ref() const;                                                                                            ///< @brief returns the ref allele in this Variant record
-  std::vector<std::string> alt() const;                                                                               ///< @brief returns the vectors of alt alleles in this Variant record
+  std::string id() const;                                                                                     ///< @brief returns the variant id field (typically dbsnp id)
+  std::string ref() const;                                                                                    ///< @brief returns the ref allele in this Variant record
+  std::vector<std::string> alt() const;                                                                       ///< @brief returns the vectors of alt alleles in this Variant record
 
   // filter field getter
-  VariantFilters filters() const;                                                                                     ///< @brief returns a vector-like object with all the filters for this record
-  bool has_filter(const std::string& filter) const;                                                                   ///< @brief checks for the existence of a filter in this record
+  VariantFilters filters() const;                                                                             ///< @brief returns a vector-like object with all the filters for this record
+  bool has_filter(const std::string& filter) const;                                                           ///< @brief checks for the existence of a filter in this record
 
-  // standard format field getters
-  bool is_hom_ref(const uint32_t sample_index) const;                                                                 ///< @brief whether or not the sample in sample_index is hom_ref @warning current implementation is solely based on PL (this will be changed in the future)
-  bool is_het(const uint32_t sample_index) const;                                                                     ///< @brief whether or not the sample in sample_index is het @warning current implementation is solely based on PL (this will be changed in the future)
-  bool is_hom_var(const uint32_t sample_index) const;                                                                 ///< @brief whether or not the sample in sample_index is hom_var @warning current implementation is solely based on PL (this will be changed in the future)
-  VariantField<VariantFieldValue<int32_t>> genotype_quals() const;                                                    ///< @brief returns a random access object with all the GQ values for all samples contiguously in memory.
-  VariantField<VariantFieldValue<int32_t>> phred_likelihoods() const;                                                 ///< @brief returns a random access object with all the PL values for all samples contiguous in memory.
+  // standard individual field getters (a.k.a "format fields")
+  VariantField<VariantFieldValue<int32_t>> genotype_quals() const;                                            ///< @brief returns a random access object with all the GQ values for all samples contiguously in memory.
+  VariantField<VariantFieldValue<int32_t>> phred_likelihoods() const;                                         ///< @brief returns a random access object with all the PL values for all samples contiguous in memory.
+  VariantField<Genotype> genotypes() const;                                                                   ///< @brief returns a random access object with all the values in a given GT tag for all samples contiguous in memory. @warning Only int8_t GT fields have been tested. @warning Missing GT fields are untested.
 
-  // generic format field getters
-  VariantField<VariantFieldValue<int32_t>> generic_integer_format_field(const std::string& tag) const;                ///< @brief returns a random access object with all the values in a give foramt field tag in integer format for all samples contiguous in memory.
-  VariantField<VariantFieldValue<float>> generic_float_format_field(const std::string& tag) const;                    ///< @brief returns a random access object with all the values in a give foramt field tag in float format for all samples contiguous in memory.
-  VariantField<VariantFieldValue<std::string>> generic_string_format_field(const std::string& tag) const;             ///< @brief returns a random access object with all the values in a give foramt field tag in string format for all samples contiguous in memory. @warning not working at the moment due to bug in htslib
+  // generic individual field getters (a.k.a "format fields")
+  VariantField<VariantFieldValue<int32_t>> integer_individual_field(const std::string& tag) const;            ///< @brief returns a random access object with all the values in a give individual field tag in integer format for all samples contiguous in memory.
+  VariantField<VariantFieldValue<float>> float_individual_field(const std::string& tag) const;                ///< @brief returns a random access object with all the values in a give individual field tag in float format for all samples contiguous in memory.
+  VariantField<VariantFieldValue<std::string>> string_individual_field(const std::string& tag) const;         ///< @brief returns a random access object with all the values in a give individual field tag in string format for all samples contiguous in memory. @warning not working at the moment due to bug in htslib
 
-  VariantField<Genotype> genotypes() const;                                                                           ///< @brief returns a random access object with all the values in a given GT tag for all samples contiguous in memory. @warning Only int8_t GT fields have been tested. @warning Missing GT fields are untested.
+  // generic shared field getters (a.k.a "info fields")
+  std::vector<int32_t> integer_shared_field(const std::string& tag) const;                                    ///< @brief returns a random access object with all the values in a given shared field tag in integer format for all samples contiguous in memory.
+  std::vector<float> float_shared_field(const std::string& tag) const;                                        ///< @brief returns a random access object with all the values in a given shared field tag in float format for all samples contiguous in memory.
+  std::vector<std::string> string_shared_field(const std::string& tag) const;                                 ///< @brief returns a random access object with all the values in a given shared field tag in string format for all samples contiguous in memory.
+  std::vector<bool> boolean_shared_field(const std::string& tag) const;                                       ///< @brief returns a random access object with all the values in a given shared field tag in boolean format for all samples contiguous in memory.
 
-  // generic info field getters
-  // NOTE: Errors in the return info field type are currently returned as empty vectors, not exceptions.
-  std::vector<int32_t> generic_integer_info_field(const std::string& tag) const;                                      ///< @brief returns a random access object with all the values in a given info field tag in integer format for all samples contiguous in memory.
-  std::vector<float> generic_float_info_field(const std::string& tag) const;                                          ///< @brief returns a random access object with all the values in a given info field tag in float format for all samples contiguous in memory.
-  std::vector<std::string> generic_string_info_field(const std::string& tag) const;                                   ///< @brief returns a random access object with all the values in a given info field tag in string format for all samples contiguous in memory.
-  std::vector<bool> generic_boolean_info_field(const std::string& tag) const;                                         ///< @brief returns a random access object with all the values in a given info field tag in boolean format for all samples contiguous in memory.
-
-  /**
-  * @brief returns a bitset indicating the samples selected according to unary predicate.
-  * */
-  template <class FF>
-  static boost::dynamic_bitset<> select_if(
-      const VariantFieldIterator<FF>& first,                                                                          ///< Iterator to the initial position in a sequence. The range includes the element pointed by first.
-      const VariantFieldIterator<FF>& last,                                                                           ///< Iterator to the last position in a sequence. The range does not include the element pointed by last.
-      const std::function<bool (const FF& value)> pred)                                                               ///< Unary predicate function that accepts an element in range [first, last) as argument and returns a value convertible to bool. The value returned indicates whether the element is considered a match in the context of this function. @note The function shall not modify its argument. @note This can either be a function pointer or a function object.
+  template <class FF>                                                                                         ///< @tparam any type that can be instantiated in a VariantFieldIterator<FF>
+  static boost::dynamic_bitset<> select_if(                                                                   ///< @brief returns a bitset indicating the samples selected according to unary predicate.
+      const VariantFieldIterator<FF>& first,                                                                  ///< Iterator to the initial position in a sequence. The range includes the element pointed by first.
+      const VariantFieldIterator<FF>& last,                                                                   ///< Iterator to the last position in a sequence. The range does not include the element pointed by last.
+      const std::function<bool (const FF& value)> pred)                                                       ///< Unary predicate function that accepts an element in range [first, last) as argument and returns a value convertible to bool. The value returned indicates whether the element is considered a match in the context of this function. @note The function shall not modify its argument. @note This can either be a function pointer or a function object.
   {
     const auto n_samples = last - first; // HINT: This isn't basic pointer subtraction, it is a customized C++ operator overload that computes the number of samples between two VariantFieldIterator objects. Took a while to debug when it was not fully tested. -kshakir
     auto selected_samples = boost::dynamic_bitset<>(n_samples);
@@ -88,11 +80,11 @@ class Variant {
   }
 
  private:
-  std::shared_ptr<bcf_hdr_t> m_header;                                                                                ///< @brief htslib variant header pointer
-  std::shared_ptr<bcf1_t> m_body;                                                                                     ///< @brief htslib variant body pointer
+  std::shared_ptr<bcf_hdr_t> m_header;                                                                        ///< @brief htslib variant header pointer
+  std::shared_ptr<bcf1_t> m_body;                                                                             ///< @brief htslib variant body pointer
 
-  inline bcf_fmt_t* find_format_field_by_tag(const std::string& tag) const;
-  template <typename TYPE> inline std::vector<TYPE> generic_info_field(const std::string& tag, const int type) const;
+  inline bcf_fmt_t* find_individual_field_by_tag(const std::string& tag) const;
+  template <typename TYPE> inline std::vector<TYPE> shared_field(const std::string& tag, const int type) const;
   inline bool is_this_genotype(const DiploidPLGenotype& genotype, const uint32_t sample_index) const;
 
   friend class VariantWriter;

--- a/gamgee/variant_header.cpp
+++ b/gamgee/variant_header.cpp
@@ -66,16 +66,16 @@ vector<string> VariantHeader::filters() const {
   return find_fields_of_type(m_header.get(), BCF_HL_FLT);
 }
 
-vector<string> VariantHeader::info_fields() const {
+vector<string> VariantHeader::shared_fields() const {
   return find_fields_of_type(m_header.get(), BCF_HL_INFO);
 }
 
-vector<string> VariantHeader::format_fields() const {
+vector<string> VariantHeader::individual_fields() const {
   return find_fields_of_type(m_header.get(), BCF_HL_FMT);
 }
 
-bool VariantHeader::has_format_field(const string field) const {
-  const auto& fields = format_fields();
+bool VariantHeader::has_individual_field(const string field) const {
+  const auto& fields = individual_fields();
   return find(fields.begin(), fields.end(), field) != fields.end();
 }
 

--- a/gamgee/variant_header.h
+++ b/gamgee/variant_header.h
@@ -31,12 +31,12 @@ class VariantHeader {
    */
   uint32_t n_samples() const { return uint32_t(m_header->n[BCF_DT_SAMPLE]); }  
 
-  std::vector<std::string> filters()       const; ///< @brief builds a vector with the filters 
-  std::vector<std::string> samples()       const; ///< @brief builds a vector with the names of the samples 
-  std::vector<std::string> chromosomes()   const; ///< @brief builds a vector with the contigs 
-  std::vector<std::string> info_fields()   const; ///< @brief builds a vector with the info fields 
-  std::vector<std::string> format_fields() const; ///< @brief builds a vector with the format fields
-  bool has_format_field(const std::string)        const; ///< @brief checks if format field has the given field
+  std::vector<std::string> filters() const;           ///< @brief builds a vector with the filters
+  std::vector<std::string> samples() const;           ///< @brief builds a vector with the names of the samples
+  std::vector<std::string> chromosomes() const;       ///< @brief builds a vector with the contigs
+  std::vector<std::string> shared_fields() const;     ///< @brief builds a vector with the info fields
+  std::vector<std::string> individual_fields() const; ///< @brief builds a vector with the format fields
+  bool has_individual_field(const std::string) const; ///< @brief checks if the format field has the given field
 
   void advanced_merge_header(const VariantHeader& other) { bcf_hdr_combine(other.m_header.get(), m_header.get()); }
 

--- a/gamgee/variant_header_builder.cpp
+++ b/gamgee/variant_header_builder.cpp
@@ -43,7 +43,7 @@ void VariantHeaderBuilder::add_filter(const string& id, const string& descriptio
   bcf_hdr_append(m_header.get(), s.c_str());
 }
 
-void VariantHeaderBuilder::add_info_field(const string& id, const string& number, const string& type, const string& description, const string& source, const string& version, const string& extra) {
+void VariantHeaderBuilder::add_shared_field(const string& id, const string& number, const string& type, const string& description, const string& source, const string& version, const string& extra) {
   auto s = string{"##INFO=<ID=" + id};
   s.append(required_parameter("number=", number));
   s.append(required_parameter("type=", type));
@@ -55,7 +55,7 @@ void VariantHeaderBuilder::add_info_field(const string& id, const string& number
   bcf_hdr_append(m_header.get(), s.c_str());
 }
 
-void VariantHeaderBuilder::add_format_field(const string& id, const string& number, const string& type, const string& description, const string& extra) {
+void VariantHeaderBuilder::add_individual_field(const string& id, const string& number, const string& type, const string& description, const string& extra) {
   auto s = string{"##FORMAT=<ID=" + id};
   s.append(required_parameter("number=", number));
   s.append(required_parameter("type=", type));

--- a/gamgee/variant_header_builder.h
+++ b/gamgee/variant_header_builder.h
@@ -27,8 +27,8 @@ class VariantHeaderBuilder {
 
   void add_chromosome(const std::string& id, const std::string& length = "", const std::string& url = "", const std::string& extra = "");
   void add_filter(const std::string& id, const std::string& description = "", const std::string& extra = "");
-  void add_info_field(const std::string& id, const std::string& number, const std::string& type, const std::string& description = "", const std::string& source = "", const std::string& version = "", const std::string& extra = "");
-  void add_format_field(const std::string& id, const std::string& number, const std::string& type, const std::string& description = "", const std::string& extra = "");
+  void add_shared_field(const std::string& id, const std::string& number, const std::string& type, const std::string& description = "", const std::string& source = "", const std::string& version = "", const std::string& extra = "");
+  void add_individual_field(const std::string& id, const std::string& number, const std::string& type, const std::string& description = "", const std::string& extra = "");
   void add_sample(const std::string& sample);
   void add_source(const std::string& source);
 

--- a/test/variant_header_test.cpp
+++ b/test/variant_header_test.cpp
@@ -16,8 +16,8 @@ BOOST_AUTO_TEST_CASE( variant_header_builder_simple_building ) {
   const auto samples     = vector<string>{"S1", "S292", "S30034"};
   const auto chromosomes = vector<string>{"chr1", "chr2", "chr3", "chr4"};
   const auto filters     = vector<string>{"LOW_QUAL", "PASS", "VQSR_FAILED"};
-  const auto infos       = vector<string>{"DP", "MQ", "RankSum"};
-  const auto formats     = vector<string>{"GQ", "PL", "DP"};
+  const auto shareds       = vector<string>{"DP", "MQ", "RankSum"};
+  const auto individuals     = vector<string>{"GQ", "PL", "DP"};
   auto builder = VariantHeaderBuilder{};
   builder.add_source("Gamgee api test");
   builder.advanced_add_arbitrary_line("##unused=<XX=AA,Description=\"Unused generic\">");
@@ -27,18 +27,18 @@ BOOST_AUTO_TEST_CASE( variant_header_builder_simple_building ) {
     builder.add_sample(sample);
   for (const auto& filter : filters) 
     builder.add_filter(filter, "anything", "deer=vanison");
-  for (const auto& info : infos) 
-    builder.add_info_field(info, "43", "Integer", "something", "the_source", "3.4", "cow=beef");
-  for (const auto& format : formats) 
-    builder.add_format_field(format, "13", "Float", "nothing", "goat=shank");
+  for (const auto& shared : shareds) 
+    builder.add_shared_field(shared, "43", "Integer", "something", "the_source", "3.4", "cow=beef");
+  for (const auto& individual : individuals) 
+    builder.add_individual_field(individual, "13", "Float", "nothing", "goat=shank");
   const auto vh = builder.build();
   check_fields(vh.chromosomes(), chromosomes);
   check_fields(vh.samples(), samples);
   check_fields(vh.filters(), filters);
-  check_fields(vh.info_fields(), infos);
-  check_fields(vh.format_fields(), formats);
-  BOOST_CHECK(vh.has_format_field("GQ") == true);
-  BOOST_CHECK(vh.has_format_field("DP") == true);
-  BOOST_CHECK(vh.has_format_field("BLAH") == false);
+  check_fields(vh.shared_fields(), shareds);
+  check_fields(vh.individual_fields(), individuals);
+  BOOST_CHECK(vh.has_individual_field("GQ") == true);
+  BOOST_CHECK(vh.has_individual_field("DP") == true);
+  BOOST_CHECK(vh.has_individual_field("BLAH") == false);
 }
 

--- a/test/variant_reader_test.cpp
+++ b/test/variant_reader_test.cpp
@@ -108,19 +108,19 @@ void check_phred_likelihoods_api(const Variant& record, const uint32_t truth_ind
   }
 }      
 
-void check_format_field_api(const Variant& record, const uint32_t truth_index) {
-  const auto gq_int    = record.generic_integer_format_field("GQ");
-  const auto gq_float  = record.generic_float_format_field("GQ");
-  const auto gq_string = record.generic_string_format_field("GQ");
-  const auto af_int    = record.generic_integer_format_field("AF");
-  const auto af_float  = record.generic_float_format_field("AF");
-  const auto af_string = record.generic_string_format_field("AF");
-  const auto pl_int    = record.generic_integer_format_field("PL");
-  const auto pl_float  = record.generic_float_format_field("PL");
-  const auto pl_string = record.generic_string_format_field("PL");
-  const auto as_int    = record.generic_integer_format_field("AS"); // this is a string field, we should be able to create the object but not access it's elements due to lazy initialization
-  const auto as_float  = record.generic_float_format_field("AS");   // this is a string field, we should be able to create the object but not access it's elements due to lazy initialization
-  const auto as_string = record.generic_string_format_field("AS");
+void check_individual_field_api(const Variant& record, const uint32_t truth_index) {
+  const auto gq_int    = record.integer_individual_field("GQ");
+  const auto gq_float  = record.float_individual_field("GQ");
+  const auto gq_string = record.string_individual_field("GQ");
+  const auto af_int    = record.integer_individual_field("AF");
+  const auto af_float  = record.float_individual_field("AF");
+  const auto af_string = record.string_individual_field("AF");
+  const auto pl_int    = record.integer_individual_field("PL");
+  const auto pl_float  = record.float_individual_field("PL");
+  const auto pl_string = record.string_individual_field("PL");
+  const auto as_int    = record.integer_individual_field("AS"); // this is a string field, we should be able to create the object but not access it's elements due to lazy initialization
+  const auto as_float  = record.float_individual_field("AS");   // this is a string field, we should be able to create the object but not access it's elements due to lazy initialization
+  const auto as_string = record.string_individual_field("AS");
   for(auto i=0u; i != record.n_samples(); ++i) {
     BOOST_CHECK_EQUAL(gq_int[i][0], truth_gq[truth_index][i]);
     BOOST_CHECK_CLOSE(gq_float[i][0], float(truth_gq[truth_index][i]), FLOAT_COMPARISON_THRESHOLD);
@@ -143,17 +143,17 @@ void check_format_field_api(const Variant& record, const uint32_t truth_index) {
   BOOST_CHECK_THROW(as_int[0][0], invalid_argument); 
 }
 
-void check_info_field_api(const Variant& record, const uint32_t truth_index) {
-  const auto validated_actual = record.generic_boolean_info_field("VALIDATED");
+void check_shared_field_api(const Variant& record, const uint32_t truth_index) {
+  const auto validated_actual = record.boolean_shared_field("VALIDATED");
   const auto validated_expected = std::vector<bool>{truth_index == 0};
   BOOST_CHECK_EQUAL_COLLECTIONS(validated_actual.begin(), validated_actual.end(), validated_expected.begin(), validated_expected.end());
-  const auto an = record.generic_integer_info_field("AN");
+  const auto an = record.integer_shared_field("AN");
   BOOST_CHECK_EQUAL(an.size(), 1);
   BOOST_CHECK_EQUAL(an[0], 6);
-  const auto af_actual = record.generic_float_info_field("AF");
+  const auto af_actual = record.float_shared_field("AF");
   const auto af_expected = truth_index == 4 ? std::vector<float>{0.5, 0} : std::vector<float>{0.5};
   BOOST_CHECK_EQUAL_COLLECTIONS(af_actual.begin(), af_actual.end(), af_expected.begin(), af_expected.end());
-  const auto desc_actual = record.generic_string_info_field("DESC");
+  const auto desc_actual = record.string_shared_field("DESC");
   const auto desc_expected = truth_index == 0 ? std::vector<string>{"Test1,Test2"} : std::vector<string>{};
   BOOST_CHECK_EQUAL_COLLECTIONS(desc_actual.begin(), desc_actual.end(), desc_expected.begin(), desc_expected.end());
 }
@@ -235,8 +235,8 @@ BOOST_AUTO_TEST_CASE( single_variant_reader )
       check_filters_api(record, truth_index);
       check_genotype_quals_api(record,truth_index);
       check_phred_likelihoods_api(record, truth_index);
-      check_format_field_api(record, truth_index);
-      check_info_field_api(record, truth_index);
+      check_individual_field_api(record, truth_index);
+      check_shared_field_api(record, truth_index);
       check_genotype_api(record, truth_index);
       ++truth_index;
     }
@@ -337,8 +337,8 @@ BOOST_AUTO_TEST_CASE( mutliple_variant_reader_test ) {
       check_filters_api(record, truth_index);
       check_genotype_quals_api(record,truth_index);
       check_phred_likelihoods_api(record, truth_index);
-      check_format_field_api(record, truth_index);
-      check_info_field_api(record, truth_index);
+      check_individual_field_api(record, truth_index);
+      check_shared_field_api(record, truth_index);
       check_genotype_api(record, truth_index);
     }
     ++truth_index;


### PR DESCRIPTION
- eliminate is_hom_ref, is_het and is_hom_var from Variant. These should only be used inside the individual's Genotype
  - rename format_field to individual_field (also get rid of the generic_ prefix)
  - rename info_field to shared_field

fixes #123
