### PR TITLE
Missing: add empty vector overload

### DIFF
--- a/gamgee/missing.h
+++ b/gamgee/missing.h
@@ -4,6 +4,7 @@
 #include "sam_tag.h"
 #include "htslib/vcf.h"
 
+#include <vector>
 #include <string>
 #include <cmath>
 
@@ -33,6 +34,15 @@ template <class MISSING_TYPE>
 inline bool missing(const MISSING_TYPE& value) {
   return value.missing();
 }
+
+/**
+ * Missing overload for functions that return a vector of values. It only applies if the entire vector is missing.
+ * @tparam VALUE any type that can be fit into a container. Any type, really.
+ * @param v any vector
+ * @return true if the vector is empty (therefore the value that was returned is missing)
+ */
+template <class VALUE>
+inline bool missing(const std::vector<VALUE>& v) { return v.empty(); }
 
 }
 

--- a/test/variant_reader_test.cpp
+++ b/test/variant_reader_test.cpp
@@ -156,6 +156,11 @@ void check_shared_field_api(const Variant& record, const uint32_t truth_index) {
   const auto desc_actual = record.string_shared_field("DESC");
   const auto desc_expected = truth_index == 0 ? std::vector<string>{"Test1,Test2"} : std::vector<string>{};
   BOOST_CHECK_EQUAL_COLLECTIONS(desc_actual.begin(), desc_actual.end(), desc_expected.begin(), desc_expected.end());
+  BOOST_CHECK(missing(record.boolean_shared_field("NON_EXISTING")));
+  BOOST_CHECK(missing(record.integer_shared_field("NON_EXISTING")));
+  BOOST_CHECK(missing(record.float_shared_field("NON_EXISTING")));  
+  BOOST_CHECK(missing(record.string_shared_field("NON_EXISTING"))); 
+  if (truth_index != 0) BOOST_CHECK(missing(desc_actual)); // testing a missing field that is actually present in the header
 }
 
 void check_genotype_api(const Variant& record, const uint32_t truth_index) {


### PR DESCRIPTION
testing with non-existing shared field in the variant_reader_test. Not
ideal, but there is really no real case where we want to test an empty
vector return value. This is more of a thing for the posteriority I
would say.

fixes #106 
