### PR TITLE
IndividualField: add operator== and operator!=

### DIFF
--- a/gamgee/individual_field.h
+++ b/gamgee/individual_field.h
@@ -101,6 +101,32 @@ class IndividualField {
    * @param other another IndividualField object
    */
   IndividualField& operator=(IndividualField&& other) = default;
+
+  /**
+   * @brief compares two IndividualField objects in the following order: memory address, size and values. 
+   * @param other something to compare to
+   * @return true if the objects are the same (memory address-wise), or contain exactly the same values. Value comparison is dictated by TYPE's operator== implementation
+   */
+  bool operator==(const IndividualField& other) const {
+    if (this == &other) 
+      return true;
+    if (size() != other.size()) 
+      return false;
+    for (auto i=0u; i != size(); ++i) {
+      if (operator[](i) != other[i])
+        return false;
+    }
+    return true;
+  }
+
+  /**
+   * @brief compares two IndividualField objects in the following order: memory address, size and values. 
+   * @param other something to compare to
+   * @return true if the objects are not the same (memory address-wise), or contain different number of values, or the values are not exactly the same. Value comparison is dictated by TYPE's operator== implementation
+   */
+  bool operator!=(const IndividualField& other) const {
+    return !(*this == other);
+  }
   
   /**
    * @brief random access to the value of a given sample for reading or writing

--- a/gamgee/individual_field_value.h
+++ b/gamgee/individual_field_value.h
@@ -103,6 +103,32 @@ class IndividualFieldValue {
   }
 
   /**
+   * @brief compares two IndividualFieldValue objects in the following order: memory address, size and values. 
+   * @param other something to compare to
+   * @return true if the objects are the same (memory address-wise), or contain exactly the same values. Value comparison is dictated by TYPE's operator== implementation
+   */
+  bool operator==(const IndividualFieldValue& other) const {
+    if (this == &other) 
+      return true;
+    if (size() != other.size()) 
+      return false;
+    for (auto i=0u; i != size(); ++i) {
+      if (operator[](i) != other[i])
+        return false;
+    }
+    return true;
+  }
+
+  /**
+   * @brief compares two IndividualFieldValue objects in the following order: memory address, size and values. 
+   * @param other something to compare to
+   * @return true if the objects are not the same (memory address-wise), or contain different number of values, or the values are not exactly the same. Value comparison is dictated by TYPE's operator== implementation
+   */
+  bool operator!=(const IndividualFieldValue& other) const {
+    return !(*this == other);
+  }
+
+  /**
    * @brief random access to the value of a given sample for reading or writing
    * @param index must be between 0 and the number of values per sample for this record 
    * @note implementation guarantees this operation to be O(1)

--- a/test/variant_reader_test.cpp
+++ b/test/variant_reader_test.cpp
@@ -167,12 +167,13 @@ void check_individual_field_api(const Variant& record, const uint32_t truth_inde
   BOOST_CHECK_THROW(record.integer_individual_field(as_idx), runtime_error);
   BOOST_CHECK_THROW(record.float_individual_field(as_idx), runtime_error);
   
-  // need operator== to make these easy to write.
-  // 
-  // BOOST_CHECK_EQUAL(gq_int, record.integer_individual_field("GQ"));
-  // BOOST_CHECK_EQUAL(af_float, record.float_individual_field("AF"));
-  // BOOST_CHECK_EQUAL(pl_int, record.integer_individual_field("PL"));
-  // BOOST_CHECK_EQUAL(as_string, record.string_individual_field("AS"));
+  BOOST_CHECK(gq_int == record.integer_individual_field("GQ"));
+  BOOST_CHECK(af_float == record.float_individual_field("AF"));
+  BOOST_CHECK(pl_int == record.integer_individual_field("PL"));
+  BOOST_CHECK(as_string == record.string_individual_field("AS"));
+  BOOST_CHECK(gq_int != record.individual_field_as_integer("AF"));
+  BOOST_CHECK(pl_float != record.individual_field_as_float("GQ"));
+  BOOST_CHECK(as_string != record.individual_field_as_string("PL"));
 
   for(auto i=0u; i != record.n_samples(); ++i) {
     BOOST_CHECK_EQUAL(gq_int[i][0], truth_gq[truth_index][i]);


### PR DESCRIPTION
Add implementation of the two operators for both IndividualField and
IndividualFieldValue so we can write tests more easily and compare
objects. Comparison is based on value equality. The Genotype class
already had the operators implemented (thanks @kshakir)

fixes #187
