### PR TITLE
bcf_close crashes when it sees a nullptr

### DIFF
--- a/gamgee/multiple_variant_reader.h
+++ b/gamgee/multiple_variant_reader.h
@@ -66,7 +66,8 @@ class MultipleVariantReader {
    */
   ~MultipleVariantReader() {
     for (auto file_ptr : m_variant_files)
-      bcf_close(file_ptr);
+      if (file_ptr != nullptr)
+        bcf_close(file_ptr);
   }
 
   /**

--- a/gamgee/variant_reader.h
+++ b/gamgee/variant_reader.h
@@ -124,7 +124,8 @@ class VariantReader {
    * @brief closes the file stream if there is one (in case we are reading a variant file)
    */
   ~VariantReader() {
-    bcf_close(m_variant_file_ptr);
+    if (m_variant_file_ptr != nullptr)
+      bcf_close(m_variant_file_ptr);
   }
 
   /**

--- a/gamgee/variant_writer.cpp
+++ b/gamgee/variant_writer.cpp
@@ -15,7 +15,8 @@ VariantWriter::VariantWriter(const VariantHeader& header, const std::string& out
 }
 
 VariantWriter::~VariantWriter() {
-  bcf_close(m_out_file);
+  if (m_out_file != nullptr)
+    bcf_close(m_out_file);
 }
 
 void VariantWriter::add_header(const VariantHeader& header) { 


### PR DESCRIPTION
Also true for hts_close but we don't have any of those.
