### PR TITLE
Exceptions: move all exceptions to exceptions.h

### DIFF
--- a/gamgee/exceptions.h
+++ b/gamgee/exceptions.h
@@ -1,0 +1,23 @@
+#ifndef gamgee__exceptions__guard
+#define gamgee__exceptions__guard
+
+#include <boost/format.hpp>
+
+#include <exception>
+#include<string>
+
+namespace gamgee {
+
+/**
+ * @brief an exception class for the case where a single input is required, but more is provided
+ */
+class SingleInputException : public std::runtime_error {
+ public:
+  SingleInputException(const std::string& vector_name, const size_t size) :
+    std::runtime_error{(boost::format("Error: single input required, but vector %s has size %d") % vector_name % size).str()} { }
+};
+
+} // end of namespace gamgee
+
+#endif // end of gamgee__exceptions__guard
+

--- a/gamgee/fastq_reader.cpp
+++ b/gamgee/fastq_reader.cpp
@@ -1,7 +1,7 @@
 #include "fastq_reader.h"
 #include "fastq_iterator.h"
 
-#include "utils/utils.h"
+#include "exceptions.h"
 
 #include <string>
 #include <iostream>
@@ -22,7 +22,7 @@ FastqReader::FastqReader(const std::string& filename) {
 
 FastqReader::FastqReader(const std::vector<std::string>& filenames) {
   if (filenames.size() > 1)
-    throw utils::SingleInputException{"filenames", filenames.size()};
+    throw SingleInputException{"filenames", filenames.size()};
   if (!filenames.empty()) {
     m_file_stream.open(filenames.front());
     m_input_stream = &m_file_stream;

--- a/gamgee/gamgee.h
+++ b/gamgee/gamgee.h
@@ -18,4 +18,6 @@
 
 #include "missing.h"
 
+#include "exceptions.h"
+
 #endif  /* gamgee__gamgee__guard */

--- a/gamgee/sam_reader.h
+++ b/gamgee/sam_reader.h
@@ -4,7 +4,7 @@
 #include "sam_iterator.h"
 #include "sam_pair_iterator.h"
 #include "utils/hts_memory.h"
-#include "utils/utils.h"
+#include "exceptions.h"
 
 #include "htslib/sam.h"
 
@@ -67,7 +67,7 @@ class SamReader {
       m_sam_header_ptr {}
     {
       if (filenames.size() > 1)
-        throw utils::SingleInputException{"filenames", filenames.size()};
+        throw SingleInputException{"filenames", filenames.size()};
       if (!filenames.empty()) {
         m_sam_file_ptr  = sam_open(filenames.front().empty() ? "-" : filenames.front().c_str(), "r");
         m_sam_header_ptr = utils::make_shared_sam_header(sam_hdr_read(m_sam_file_ptr));

--- a/gamgee/utils/utils.h
+++ b/gamgee/utils/utils.h
@@ -92,16 +92,6 @@ auto zip(const T&... containers) -> boost::iterator_range<boost::zip_iterator<de
     return boost::make_iterator_range(zip_begin, zip_end);
 }
 
-/**
- * @brief an exception class for the case where a single input is required, but more is provided
- */
-class SingleInputException : public std::runtime_error {
- public:
-  SingleInputException(const std::string& vector_name, const size_t size) :
-    std::runtime_error{(boost::format("Error: single input required, but vector %s has size %d") % vector_name % size).str()} { }
-};
-
-
 } // end utils namespace
 } // end gamgee namespace
 

--- a/gamgee/variant_reader.h
+++ b/gamgee/variant_reader.h
@@ -4,7 +4,7 @@
 #include "variant_header.h"
 #include "variant_iterator.h"
 #include "utils/hts_memory.h"
-#include "utils/utils.h"
+#include "exceptions.h"
 
 #include "htslib/vcf.h"
 
@@ -67,7 +67,7 @@ class VariantReader {
     m_variant_header_ptr {}
   {
     if (filenames.size() > 1)
-      throw utils::SingleInputException{"filenames", filenames.size()};
+      throw SingleInputException{"filenames", filenames.size()};
     if (!filenames.empty()) {
       m_variant_file_ptr  = bcf_open(filenames.front().empty() ? "-" : filenames.front().c_str(), "r");
       m_variant_header_ptr = utils::make_shared_variant_header(bcf_hdr_read(m_variant_file_ptr));
@@ -104,7 +104,7 @@ class VariantReader {
     m_variant_header_ptr {}
   {
     if (filenames.size() > 1)
-      throw utils::SingleInputException{"filenames", filenames.size()};
+      throw SingleInputException{"filenames", filenames.size()};
     if (!filenames.empty()) {
       m_variant_file_ptr  = bcf_open(filenames.front().empty() ? "-" : filenames.front().c_str(), "r");
       m_variant_header_ptr = utils::make_shared_variant_header(bcf_hdr_read(m_variant_file_ptr));


### PR DESCRIPTION
All gamgee specific exceptions should be declared in exceptions.h and
gamgee.h will extend it's visibility to all users of the library.

fixes #170
