### PR TITLE
TestUtils: add copy/move operation test functions

### DIFF
--- a/gamgee/fastq.h
+++ b/gamgee/fastq.h
@@ -27,18 +27,33 @@ class Fastq {
       m_name {name}, m_comment {comment}, m_sequence{sequence}, m_quals{quals} 
   {}
 
+  Fastq(const Fastq&) = default;
+  Fastq& operator=(const Fastq&) = default;
+  Fastq(Fastq&&) = default;
+  Fastq& operator=(Fastq&&) = default;
+
   
   /**
     * @brief inequality comparison of all fields in the record
     *
+    * @return true if any field differs (string comparison)
+    */
+  bool operator!=(const Fastq& other) const {
+      return !(*this == other); 
+  }
+  
+  /**
+    * @brief equality comparison of all fields in the record
+    *
     * @return true only if every field is the same (string comparison)
     */
-  bool operator!=(const Fastq& other) {
+  bool operator==(const Fastq& other) const {
       return m_name     == other.m_name     &&
              m_comment  == other.m_comment  &&
              m_sequence == other.m_sequence &&
              m_quals    == other.m_quals;
   }
+
 
   std::string name() const                       { return m_name;         }
   std::string comment() const                    { return m_comment;      }

--- a/gamgee/indexed_sam_reader.h
+++ b/gamgee/indexed_sam_reader.h
@@ -56,10 +56,14 @@ class IndexedSamReader {
     IndexedSamReader& operator=(IndexedSamReader&& other) = default;
 
     /**
-     * @brief no copy construction/assignment allowed for iterators and readers
+     * @brief no copy construction/assignment allowed for input iterators and readers
      */
     IndexedSamReader(const IndexedSamReader& other) = delete;
-    IndexedSamReader& operator=(const IndexedSamReader& other) = delete;
+
+    /**
+     * @copydoc IndexedSamReader(IndexedSamReader&)
+     */
+    IndexedSamReader& operator=(IndexedSamReader& other) = delete;
 
     /**
      * @brief creates a ITERATOR pointing at the start of the input stream (needed by for-each

--- a/test/fastq_reader_test.cpp
+++ b/test/fastq_reader_test.cpp
@@ -1,6 +1,7 @@
-#include "../gamgee/fastq_reader.h"
-
 #include <boost/test/unit_test.hpp>
+
+#include "fastq_reader.h"
+#include "test_utils.h"
 
 using namespace std;
 using namespace gamgee;
@@ -44,4 +45,23 @@ BOOST_AUTO_TEST_CASE( read_fastq_vector )
 BOOST_AUTO_TEST_CASE( read_fastq_vector_too_large )
 {
   BOOST_CHECK_THROW(vector_too_large("testdata/complete_same_seq.fa"), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE( fastq_copy_and_move_constructor ) {
+  auto it = FastqReader{"testdata/complete_same_seq.fa"}.begin();
+  auto c0 = *it;
+  auto copies = check_copy_constructor(c0);
+  auto c1 = get<0>(copies);
+  auto c2 = get<1>(copies);
+  auto c3 = get<2>(copies);
+  BOOST_CHECK(c0 == c1);
+  BOOST_CHECK(c0 == c2);
+  BOOST_CHECK(c0 == c3);
+  c1.set_name("modified");
+  BOOST_CHECK(c1 != c0);
+  BOOST_CHECK(c1 != c2);
+  auto m0 = *it;
+  auto m1 = check_move_constructor(m0);
+  auto m2 = *it;
+  BOOST_CHECK(m1 == m2);
 }

--- a/test/interval_test.cpp
+++ b/test/interval_test.cpp
@@ -1,6 +1,7 @@
-#include "interval.h"
-
 #include <boost/test/unit_test.hpp>
+
+#include "interval.h"
+#include "test_utils.h"
 
 #include <iostream>
 #include <vector>
@@ -118,4 +119,20 @@ BOOST_AUTO_TEST_CASE( interval_equality )
   BOOST_CHECK(i == j);
   i.set_chr("TAST");
   BOOST_CHECK(!(i == j));
+}
+
+BOOST_AUTO_TEST_CASE( interval_copy_and_move_constructors ) {
+  auto i0 = Interval {"A", 1'000, 2'000};
+  auto copies = check_copy_constructor(i0);
+  auto c2 = get<1>(copies);
+  BOOST_CHECK(i0 ==  get<0>(copies));
+  BOOST_CHECK(i0 == c2);
+  BOOST_CHECK(i0 == get<2>(copies));
+  c2.set_start(1'500);
+  BOOST_CHECK(i0 != c2);
+  BOOST_CHECK(c2 != get<0>(copies));
+  BOOST_CHECK(c2 != get<1>(copies));
+  BOOST_CHECK(c2 != get<2>(copies)); 
+  auto m1 = check_move_constructor(get<0>(copies));
+  BOOST_CHECK(i0 == m1);
 }

--- a/test/sam_header_test.cpp
+++ b/test/sam_header_test.cpp
@@ -1,6 +1,7 @@
-#include "sam_reader.h"
-
 #include <boost/test/unit_test.hpp>
+
+#include "sam_reader.h"
+#include "test_utils.h"
 
 using namespace std;
 using namespace gamgee;
@@ -18,11 +19,8 @@ BOOST_AUTO_TEST_CASE( sam_header ) {
 /** @todo Need a way to modify the header in between these copies/moves to make sure these are working properly! */
 BOOST_AUTO_TEST_CASE( sam_header_constructors ) {
   auto reader = SingleSamReader{"testdata/test_simple.bam"};
-  auto header1 = reader.header();
-  auto header2 = header1;                  // copy constructor
-  auto header3 = std::move(header1);       // move constructor
-  header1 = header2;                       // copy assignment
-  const auto header4 = std::move(header1); // transfer header1's memory somewhere else so we can reuse it for move assignment
-  header1 = std::move(header3);            // move assignment
-  header1 = header1;                       // self assignment
+  auto h0 = reader.header();
+  auto copies = check_copy_constructor(h0);
+  auto moves = check_copy_constructor(h0);
+  // need builder to be able to modify the header and check. At least this test will blow up if something is not functional.
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -1,0 +1,53 @@
+#ifndef gamgee_test_utils__guard
+#define gamgee_test_utils__guard
+
+#include <tuple>
+
+/**
+ * @brief test code for copy construction and copy assignment for any copy enabled object
+ *
+ * This tests copy construction, copy assignment and checks for self copy
+ * assignment. The starting object is copied to three different objects using
+ * all the above procedures. It returns a tuple with all three copied objects
+ * for you to verify that the copy occurred and that it didn't affect the
+ * original object. This is extremely useful when writing tests for a new class.
+ * 
+ * @tparam T any class that is copy constructible and copy assignable
+ * @param original a simple object of class T to make the copies from
+ * @return a tuple with all three copied objects
+ */
+template <class T>
+std::tuple<T, T, T> check_copy_constructor (T& original) {
+  auto obj2 = original; // copy construction
+  auto obj3 = original; // copy construction
+  obj2 = obj2;          // check self copy-assignment
+  obj3 = obj2;          // copy assignment
+  return std::make_tuple(original, obj2, obj3);
+}
+
+ /**
+ * @brief test code for move construction and move assignment for any move enabled object
+ *
+ * This tests move construction, move assignment and checks for self move
+ * assignment. The starting object is moved through three different objects using 
+ * all the above procedures. It returns the final moved to object
+ * for you to verify that the move occurred and that it still matches the 
+ * original object. This is extremely useful when writing tests for a new class.
+ *
+ * @warning the original object passed in will be forcefully moved from, therefore in unusable state.
+ * 
+ * @tparam T any class that is move constructible and move assignable
+ * @param original a simple object of class T to move from (it will be destroyed)
+ * @return the last moved to object
+ */
+template <class T>
+T check_move_constructor (T& original) {
+  auto obj2 = std::move(original); // move construction
+  auto obj3 = std::move(obj2);     // create a new object (we can't rely on default construction)
+  obj2 = std::move(obj3);          // check move-assignment
+  return obj2;
+}
+
+
+
+#endif

--- a/test/variant_header_test.cpp
+++ b/test/variant_header_test.cpp
@@ -1,4 +1,5 @@
 #include <boost/test/unit_test.hpp>
+#include "test_utils.h"
 #include "variant_header_builder.h"
 #include "missing.h"
 
@@ -50,5 +51,19 @@ BOOST_AUTO_TEST_CASE( variant_header_builder_simple_building ) {
   BOOST_CHECK(missing(vh.field_index("MISSING")));
   BOOST_CHECK(missing(vh.field_index("MISSING")));
   BOOST_CHECK_EQUAL(vh.field_index("PASS"), 0);
+}
+
+BOOST_AUTO_TEST_CASE( variant_header_move_and_copy_constructor ) {
+  auto builder = VariantHeaderBuilder{};
+  builder.add_sample("S1");
+  auto h0 = builder.build();
+  auto copies = check_copy_constructor(h0);
+  auto c2 = get<2>(copies);
+  BOOST_CHECK_EQUAL_COLLECTIONS(h0.samples().begin(), h0.samples().end(), get<0>(copies).samples().begin(), get<0>(copies).samples().end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(h0.samples().begin(), h0.samples().end(), get<1>(copies).samples().begin(), get<1>(copies).samples().end());
+  BOOST_CHECK_EQUAL_COLLECTIONS(h0.samples().begin(), h0.samples().end(), c2.samples().begin(), c2.samples().end());
+  auto m1 = check_move_constructor(get<1>(copies));
+  BOOST_CHECK_EQUAL_COLLECTIONS(h0.samples().begin(), h0.samples().end(), m1.samples().begin(), m1.samples().end());
+  // can't modify a variant header... so this is it for the test.
 }
 

--- a/test/variant_reader_test.cpp
+++ b/test/variant_reader_test.cpp
@@ -5,6 +5,7 @@
 #include "indexed_variant_reader.h"
 #include "indexed_variant_iterator.h"
 #include "missing.h"
+#include "test_utils.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -478,31 +479,6 @@ BOOST_AUTO_TEST_CASE( single_variant_reader_vector_too_large )
   BOOST_CHECK_THROW((SingleVariantReader{vector<string>{"testdata/test_variants.vcf", "testdata/test_variants.vcf"}}), std::runtime_error);
 }
 
-BOOST_AUTO_TEST_CASE( single_variant_reader_move_test ) {
-  auto reader1 = SingleVariantReader{"testdata/test_variants.vcf"};
-
-  // move construct
-  auto reader2 = std::move(reader1);
-
-  // move assign
-  auto reader3 = SingleVariantReader{"testdata/test_variants_missing_data.vcf"};        // different file
-  reader3 = std::move(reader2);
-
-  auto truth_index = 0u;
-  for (const auto& record : reader3) {
-    check_variant_basic_api(record, truth_index);
-    check_quals_api(record, truth_index);
-    check_alt_api(record, truth_index);
-    check_filters_api(record, truth_index);
-    check_genotype_quals_api(record,truth_index);
-    check_phred_likelihoods_api(record, truth_index);
-    check_individual_field_api(record, truth_index);
-    check_shared_field_api(record, truth_index);
-    check_genotype_api(record, truth_index);
-    ++truth_index;
-  }
-}
-
 BOOST_AUTO_TEST_CASE( variant_iterator_move_test ) {
   auto reader = SingleVariantReader{"testdata/test_variants.vcf"};
   auto iter1 = reader.begin();
@@ -807,4 +783,11 @@ BOOST_AUTO_TEST_CASE( indexed_variant_iterator_move_test ) {
     BOOST_CHECK_EQUAL(rec1.alignment_start(), rec2.alignment_start());
     BOOST_CHECK_EQUAL(rec1.alignment_start(), rec3.alignment_start());
   }
+}
+
+BOOST_AUTO_TEST_CASE( variant_reader_move_constructor ) {
+  auto r0 = SingleVariantReader{"testdata/test_variants.bcf"};
+  auto r1 = SingleVariantReader{"testdata/test_variants.bcf"};
+  auto m1 = check_move_constructor(r1);
+  BOOST_CHECK_EQUAL(r0.begin().operator*().alignment_start(), m1.begin().operator*().alignment_start());
 }


### PR DESCRIPTION
Testing move and copy operations are something we do all the time and
it's not always trivial. It includes a lot of boiler plate code. These
two template functions take away the boiler plate and test the following
aspects of the copy and move operations:
- copy and move construction
- copy and move assignment
- check that self assignment doesn't destroy the object

The copy version returns all three copies made to test the functionality.

The move version returns the final moved to object. Note that the move
function will move from the parameter passed in, so that parameter
becomes unusable.

fixes #206
