### PR TITLE
Update htslib submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/htslib"]
   path = lib/htslib
-  url = git://github.com/MauricioCarneiro/htslib.git
+  url = ../htslib.git
   branch = develop


### PR DESCRIPTION
Two motivators for this change:
- Maurício mentioned in a phone call that broadinstitute/htslib.git would be the correct repository to use
- NVIDIA would benefit from having the submodule referenced as a relative path, as that makes life easier for our automated build mechanisms
