### PR TITLE
Enable the use of SyncedVariantReader with no intervals

### DIFF
--- a/gamgee/indexed_variant_reader.h
+++ b/gamgee/indexed_variant_reader.h
@@ -34,7 +34,7 @@ class IndexedVariantReader {
    * parsing them into Variant objects
    *
    * @param filename the name of the variant file
-   * @param interval_list a vector of intervals represented by strings
+   * @param interval_list a vector of intervals represented by strings.  Empty vector for all intervals.
    *
    */
   IndexedVariantReader(const std::string& filename, const std::vector<std::string> interval_list) :

--- a/gamgee/synced_variant_reader.h
+++ b/gamgee/synced_variant_reader.h
@@ -40,15 +40,21 @@ class SyncedVariantReader {
    * @brief opens multiple files (vcf or bcf) and allows an iterator to parse them
    *
    * @param filenames the names of the variant files
-   * @param interval_list a comma-separated list of the intervals to traverse
+   * @param interval_list a comma-separated string of the intervals to traverse.  Empty string for all intervals.
    * @exception will throw std::runtime_error if the htslib structure cannot be initialized
    */
   SyncedVariantReader(const std::vector<std::string>& filenames, const std::string& interval_list) :
     m_synced_readers {utils::make_shared_synced_variant_reader(bcf_sr_init())}
   {
-    auto success = bcf_sr_set_regions(m_synced_readers.get(), interval_list.c_str(), 0);
-    if (success != 0)
-      throw HtslibException(success);
+    auto success = 0;
+    if (interval_list.empty()) {
+      m_synced_readers->require_index = 1;
+    }
+    else {
+      success = bcf_sr_set_regions(m_synced_readers.get(), interval_list.c_str(), 0);
+      if (success != 0)
+        throw HtslibException(success);
+    }
 
     for (const auto& filename : filenames) {
       success = bcf_sr_add_reader(m_synced_readers.get(), filename.c_str());

--- a/test/variant_reader_test.cpp
+++ b/test/variant_reader_test.cpp
@@ -792,7 +792,7 @@ const auto indexed_variant_bp_partial_joined = boost::algorithm::join(indexed_va
 
 // full interval lists
 BOOST_AUTO_TEST_CASE( synced_variant_reader_full_test ) {
-  for (const auto intervals : {indexed_variant_chrom_full_joined, indexed_variant_bp_full_joined}) {
+  for (const auto intervals : {string{""}, indexed_variant_chrom_full_joined, indexed_variant_bp_full_joined}) {
     for (const auto input_files : {indexed_variant_vcf_inputs, indexed_variant_bcf_inputs}) {
       auto truth_index = 0u;
       const auto reader = SyncedVariantReader<SyncedVariantIterator>{input_files, intervals};


### PR DESCRIPTION
Specify "all intervals" by passing in an empty string.
