### PR TITLE
IndividualFieldValue: Fix misplaced const qualifiers

### DIFF
--- a/gamgee/individual_field_value.h
+++ b/gamgee/individual_field_value.h
@@ -156,10 +156,10 @@ class IndividualFieldValue {
   uint32_t size() const { return m_format_ptr->n; } ///< @brief the number of values in this IndividualFieldValue (values per sample)
 
  private:
-  const std::shared_ptr<bcf1_t> m_body;
-  const bcf_fmt_t* const m_format_ptr;
-  uint8_t* const m_data_ptr;
-  const uint8_t m_num_bytes;
+  std::shared_ptr<bcf1_t> m_body;
+  const bcf_fmt_t* m_format_ptr;
+  uint8_t* m_data_ptr;
+  uint8_t m_num_bytes;
 
   VALUE_TYPE convert_from_byte_array(int index) const;
 };

--- a/gamgee/individual_field_value_iterator.h
+++ b/gamgee/individual_field_value_iterator.h
@@ -200,11 +200,11 @@ class IndividualFieldValueIterator : public std::iterator<std::random_access_ite
   }
 
  private:
-  const std::shared_ptr<bcf1_t> m_body;
+  std::shared_ptr<bcf1_t> m_body;
   const uint8_t* m_current_data_ptr;
-  const uint8_t* const m_original_data_ptr;
-  const uint8_t m_num_bytes;
-  const utils::VariantFieldType m_type;
+  const uint8_t* m_original_data_ptr;
+  uint8_t m_num_bytes;
+  utils::VariantFieldType m_type;
 
   VALUE_TYPE convert_from_byte_array(const uint8_t* data_ptr, int index) const;
 };


### PR DESCRIPTION
The implementation of IndividualFieldValue::operator= assigns new
values to member variables declared as const, which is not legal.
NVIDIA's nvcc compiler front-end signals this as a problem, even though
gcc sometimes accepts it.

Remove the const qualifiers from IndividualFieldValue member variables.
Apply same fix to IndividualFieldValueIterator members as well.
