### PR TITLE
Make gamgee::missing(float) distinguish between missing values and other kinds of NaN values

### DIFF
--- a/gamgee/missing.h
+++ b/gamgee/missing.h
@@ -2,6 +2,7 @@
 #define gamgee__missing__guard
 
 #include "sam_tag.h"
+#include "utils/utils.h"
 #include "htslib/vcf.h"
 
 #include <vector>
@@ -19,7 +20,7 @@ namespace missing_values {
 }
 
 inline bool missing (const bool value) { return !value; }                                                                       ///< Returns true if bool is false (missing).
-inline bool missing (const float value) { return isnan(value); }                                                                ///< Returns true if float is missing.
+inline bool missing (const float value) { return bcf_float_is_missing(value); }                                                 ///< Returns true if float is missing.
 inline bool missing (const int8_t value)  { return value == missing_values::int8; }                                             ///< Returns true if int8_t is missing.
 inline bool missing (const int16_t value) { return value == missing_values::int16; }                                            ///< Returns true if int16_t is missing.
 inline bool missing (const int32_t value) { return value == missing_values::int32; }                                            ///< Returns true if int32_t is missing.

--- a/test/missing_test.cpp
+++ b/test/missing_test.cpp
@@ -1,0 +1,27 @@
+#include <boost/test/unit_test.hpp>
+#include <limits>
+#include <cmath>
+
+#include "missing.h"
+#include "htslib/vcf.h"
+
+using namespace std;
+using namespace gamgee;
+
+BOOST_AUTO_TEST_CASE( detect_missing_float ) {
+  float missing_value;
+  bcf_float_set_missing(missing_value);
+  BOOST_CHECK(missing(missing_value));
+}
+
+BOOST_AUTO_TEST_CASE( distinguish_missing_float_from_other_nan_values ) {
+  // end of vector should not be confused with missing
+  float end_of_vector_value;
+  bcf_float_set_vector_end(end_of_vector_value);
+  BOOST_CHECK(! missing(end_of_vector_value));
+
+  // quiet NaN should not be confused with missing
+  float quiet_nan = std::numeric_limits<float>::quiet_NaN();
+  BOOST_CHECK(std::isnan(quiet_nan));
+  BOOST_CHECK(! missing(quiet_nan));
+}


### PR DESCRIPTION
Non-missing NaN values include the end-of-vector value and quiet NaN.
Previously missing() would return true for these values.

Fixes #157
