### PR TITLE
Banish all const member variables

### DIFF
--- a/gamgee/genotype.h
+++ b/gamgee/genotype.h
@@ -155,9 +155,9 @@ class Genotype{
   // ? begin() const;
   // ? end() const;
 
-  private:
-  const std::shared_ptr<bcf1_t> m_body;
-  const bcf_fmt_t* const m_format_ptr;
+ private:
+  std::shared_ptr<bcf1_t> m_body;
+  const bcf_fmt_t* m_format_ptr;
   const uint8_t* m_data_ptr;
 };
 

--- a/gamgee/individual_field.h
+++ b/gamgee/individual_field.h
@@ -164,7 +164,7 @@ class IndividualField {
   TYPE back() const { return operator[](m_body->n_sample - 1); }   ///< @brief convenience function to access the last element
 
  private:
-  const std::shared_ptr<bcf1_t> m_body; ///< shared ownership of the Variant record memory so it stays alive while this object is in scope
+  std::shared_ptr<bcf1_t> m_body; ///< shared ownership of the Variant record memory so it stays alive while this object is in scope
   bcf_fmt_t*  m_format_ptr;  ///< pointer to m_body structure where the data for this particular type is located.
 };
 

--- a/gamgee/sam_pair_iterator.h
+++ b/gamgee/sam_pair_iterator.h
@@ -72,7 +72,7 @@ class SamPairIterator {
 
     SamPtrQueue m_supp_alignments;                     ///< queue to hold the supplementary alignments temporarily while processing the pairs
     std::shared_ptr<htsFile> m_sam_file_ptr;           ///< pointer to the sam file
-    const std::shared_ptr<bam_hdr_t> m_sam_header_ptr; ///< pointer to the sam header
+    std::shared_ptr<bam_hdr_t> m_sam_header_ptr; ///< pointer to the sam header
     std::shared_ptr<bam1_t> m_sam_record_ptr1;         ///< pointer to the internal structure of the sam record. Useful to only allocate it once.
     std::shared_ptr<bam1_t> m_sam_record_ptr2;         ///< pointer to the internal structure of the sam record. Useful to only allocate it once.
     std::pair<Sam,Sam> m_sam_records;                  ///< temporary record to hold between fetch (operator++) and serve (operator*)

--- a/gamgee/shared_field.h
+++ b/gamgee/shared_field.h
@@ -139,9 +139,9 @@ class SharedField {
   TYPE back() const { return operator[](m_info_ptr->len - 1); }   ///< @brief convenience function to access the last element
 
  private:
-  const std::shared_ptr<bcf1_t> m_body;
-  const bcf_info_t* const m_info_ptr;
-  const uint8_t m_bytes_per_value;
+  std::shared_ptr<bcf1_t> m_body;
+  const bcf_info_t* m_info_ptr;
+  uint8_t m_bytes_per_value;
 
   TYPE convert_from_byte_array(int index) const;
 };

--- a/gamgee/shared_field_iterator.h
+++ b/gamgee/shared_field_iterator.h
@@ -138,11 +138,11 @@ class SharedFieldIterator : public std::iterator<std::random_access_iterator_tag
   }
 
  private:
-  const std::shared_ptr<bcf1_t> m_body;
+  std::shared_ptr<bcf1_t> m_body;
   const uint8_t* m_current_data_ptr;
-  const uint8_t* const m_original_data_ptr;
-  const uint8_t m_bytes_per_value;
-  const utils::VariantFieldType m_type;
+  const uint8_t* m_original_data_ptr;
+  uint8_t m_bytes_per_value;
+  utils::VariantFieldType m_type;
 
   VALUE_TYPE convert_from_byte_array(const uint8_t* data_ptr, int index) const;
 };


### PR DESCRIPTION
They prevent move operations and really make no sense. If you need to
make an object immutable, make _it_ const, not it's member variables. If
you need a class that producess immutable objects, use another design
pattern.

closes #271
