### PR TITLE
Genotype: add convenience functions: snp, indel...

### DIFF
--- a/gamgee/utils/variant_utils.h
+++ b/gamgee/utils/variant_utils.h
@@ -17,6 +17,10 @@ namespace gamgee {
  */
 void subset_variant_samples(bcf_hdr_t* hdr_ptr, const std::vector<std::string>& samples, const bool include);
 
+enum class AlleleType { REFERENCE, SNP, INSERTION, DELETION };
+
+using AlleleMask = std::vector<AlleleType>;
+
 }
 
 #endif /* gamgee__variant_utils__guard */

--- a/test/variant_test.cpp
+++ b/test/variant_test.cpp
@@ -1,0 +1,48 @@
+#include <boost/test/unit_test.hpp>
+#include "variant_reader.h"
+#include "variant.h"
+#include "utils/variant_utils.h"
+
+using namespace std;
+using namespace gamgee;
+using namespace boost;
+
+BOOST_AUTO_TEST_CASE( allele_mask_simple_snp ) {
+  const auto rec = (*(SingleVariantReader("testdata/test_variants.bcf").begin())); // take the first record
+  const auto am = rec.allele_mask();
+  BOOST_REQUIRE_EQUAL(am.size(), 2);
+  BOOST_CHECK(am[0] == AlleleType::REFERENCE);
+  BOOST_CHECK(am[1] == AlleleType::SNP);
+}
+
+BOOST_AUTO_TEST_CASE( allele_mask_simple_insertion ) {
+  auto it = SingleVariantReader("testdata/test_variants.bcf").begin(); 
+  ++it; ++it; ++it; // take the fourth record (it is an insertion)
+  const auto rec = *it;
+  const auto am = rec.allele_mask();
+  BOOST_REQUIRE_EQUAL(am.size(), 2);
+  BOOST_CHECK(am[0] == AlleleType::REFERENCE);
+  BOOST_CHECK(am[1] == AlleleType::INSERTION);
+}
+
+BOOST_AUTO_TEST_CASE( allele_mask_simple_deletion ) {
+  auto it = SingleVariantReader("testdata/test_variants.bcf").begin(); 
+  ++it; ++it; // take the third record -- this would be so much simpler with a VariantBuilder....
+  const auto rec = *it;
+  const auto am = rec.allele_mask();
+  BOOST_REQUIRE_EQUAL(am.size(), 2);
+  BOOST_CHECK(am[0] == AlleleType::REFERENCE);
+  BOOST_CHECK(am[1] == AlleleType::DELETION);
+}
+
+BOOST_AUTO_TEST_CASE( allele_mask_snp_and_insertion ) {
+  auto it = SingleVariantReader("testdata/test_variants.bcf").begin(); 
+  ++it; ++it; ++it; ++it; // take the third record -- this would be so much simpler with a VariantBuilder....
+  const auto rec = *it;
+  const auto am = rec.allele_mask();
+  BOOST_REQUIRE_EQUAL(am.size(), 3);
+  BOOST_CHECK(am[0] == AlleleType::REFERENCE);
+  BOOST_CHECK(am[1] == AlleleType::DELETION);
+  BOOST_CHECK(am[2] == AlleleType::INSERTION);
+}
+


### PR DESCRIPTION
This is a tricky request from @lbergelson which I anticipate to be a big hit
with the compbios. Everyone wants to query directly at the genotype what
kind of event it is. The problem is that doing so is expensive. One
should always strive to batch this kind of computation across all
samples using functionality like select_if or simple for_each loops.

However sometimes you want to just query one or two of these conditions
and it is nice to have such convenience functions. I strived here to
achieve as much performance as possible without increasing the state of
the Genotype object. To avoid string comparisons, all member functions
rely on an AlleleMask that pre-computes the string differences in the
alt/ref fields only once. All functions operate on key comparisons only.

Still, if you are going to use this for multiple comparisons such as:

``` c++
if (genotype.insertion() || genotype.snp() && genotype.simple())
  do_something(genotype);
```

You will most likely be better off writing your own for loop instead of
paying for 3 passes on the data. But for quick queries in data with few
alleles (like diploids) this should be fine.

closes #204
