### PR TITLE
Travis: add precompiled packages for our tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,17 @@ env:
 
 compiler:
   - clang
+  - gcc
 
 before_install:
   - sudo add-apt-repository -y ppa:boost-latest/ppa
-  - sudo add-apt-repository -y ppa:h-rayflood/llvm
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get -qq update;
 
 install:
-  - if [ "$CXX" == "g++" ]; then .travis_scripts/gcc.sh; fi
+  - .travis_scripts/boost.sh 
   - if [ "$CXX" == "clang++" ]; then .travis_scripts/clang.sh; fi
-  - .travis_scripts/boost.sh
+  - if [ "$CXX" == "g++"     ]; then .travis_scripts/gcc.sh; fi
 
 script:
   - b2 -a toolset=${CC} test cxxflags=--coverage linkflags=--coverage

--- a/.travis_scripts/clang.sh
+++ b/.travis_scripts/clang.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
-sudo apt-get install --allow-unauthenticated -qq clang-3.4 libstdc++-4.8-dev
-sudo update-alternatives --install /usr/local/bin/clang++ clang++ /usr/bin/clang++-3.4 50
+wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo apt-add-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main'
+sudo apt-get -qq update
+sudo apt-get -qq --force-yes install clang-3.5 clang-modernize-3.5 # clang-format-3.5
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.5 1
+sudo rm /usr/local/clang-3.4/bin/clang++

--- a/.travis_scripts/coveralls.sh
+++ b/.travis_scripts/coveralls.sh
@@ -2,7 +2,7 @@
 
 # Note that this only works if the tests were built using --coverage for
 # compile and link flags!
-if [ "$CXX" == "clang++" ];
+if [ "$CXX" == "g++" ];
 then
   sudo pip install cpp-coveralls
   coveralls -b . -r . -e lib -e test -e testdata -t ${COVERALLS_TOKEN}

--- a/.travis_scripts/gcc.sh
+++ b/.travis_scripts/gcc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sudo apt-get install -qq g++-4.8;
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50;
-
+wget http://www.broadinstitute.org/~carneiro/travis/gcc_4.9.1-1_amd64.deb
+sudo apt-get remove cpp libffi-dev
+sudo dpkg --install gcc_4.9.1-1_amd64.deb

--- a/.travis_scripts/update_website_dox.sh
+++ b/.travis_scripts/update_website_dox.sh
@@ -4,12 +4,8 @@ if [ "$CXX" == "clang++" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PUL
 then 
   echo -e "Downloading latest Doxygen...";
   cd ${HOME};
-  wget https://github.com/doxygen/doxygen/archive/Release_1_8_7.tar.gz -O $HOME/doxygen-1.8.7.tgz;
-  tar xzf doxygen-1.8.7.tgz;
-  cd $HOME/doxygen-Release_1_8_7;
-  ./configure > /dev/null;
-  make > /dev/null;
-  sudo make install > /dev/null;
+  wget http://www.broadinstitute.org/~carneiro/travis/doxygen_1.8.8-1_amd64.deb
+  sudo dpkg --install doxygen_1.8.8-1_amd64.deb
   cd ${HOME}/build/broadinstitute/gamgee;
   doxygen
 


### PR DESCRIPTION
- add doxygen 1.8 binary package
- add clang-3.5 + clang modernize
- add gcc 4.9

I also have a boost package compiled with gcc 4.9 but the current clang
package depends on gcc 4.8 (for stdlibc++) and resolving this was a
dependency nightmare that I decided to postpone. Boost-155 is currently
being used from a PPA.

I also added clang-format and clang-modernize #56 but I will only close
that item when we actually use them in the build process. It's available
now.

closes #57
