### PR TITLE
Move the field_type checks to VariantHeader

### DIFF
--- a/gamgee/variant.cpp
+++ b/gamgee/variant.cpp
@@ -108,14 +108,6 @@ bool Variant::has_filter(const std::string& filter) const {
 /******************************************************************************
  * Individual field API                                                       *
  ******************************************************************************/
-uint8_t Variant::individual_field_type(const std::string& tag) const {
-  return individual_field_type(get_field_index(tag));
-}
-
-uint8_t Variant::individual_field_type(const int32_t index) const {
-  return bcf_hdr_id2type(m_header.get(), BCF_HL_FMT, index);
-}
-
 IndividualField<IndividualFieldValue<int32_t>> Variant::integer_individual_field(const std::string& tag) const {
   return integer_individual_field(get_field_index(tag)); 
 }
@@ -174,14 +166,6 @@ IndividualField<IndividualFieldValue<std::string>> Variant::individual_field_as_
 /******************************************************************************
  * Shared field API                                                           *
  ******************************************************************************/
-uint8_t Variant::shared_field_type(const std::string& tag) const {
-  return shared_field_type(get_field_index(tag));
-}
-
-uint8_t Variant::shared_field_type(const int32_t index) const {
-  return bcf_hdr_id2type(m_header.get(), BCF_HL_INFO, index);
-}
-
 bool Variant::boolean_shared_field(const std::string& tag) const {
   return find_shared_field(tag) != nullptr;
 }

--- a/gamgee/variant.h
+++ b/gamgee/variant.h
@@ -51,12 +51,6 @@ class Variant {
   VariantFilters filters() const;                                                                             ///< returns a vector-like object with all the filters for this record
   bool has_filter(const std::string& filter) const;                                                           ///< checks for the existence of a filter in this record
 
-  // type checking functions: returns BCF_HT_FLAG, BCF_HT_INT, BCF_HT_REAL, BCF_HT_STR from htslib/vcf.h
-  uint8_t shared_field_type(const std::string& tag) const;                                                    ///< returns the type of this shared (info) field
-  uint8_t shared_field_type(const int32_t index) const;                                                       ///< returns the type of this shared (info) field
-  uint8_t individual_field_type(const std::string& tag) const;                                                ///< returns the type of this individual (format) field
-  uint8_t individual_field_type(const int32_t index) const;                                                   ///< returns the type of this individual (format) field
-
   // individual field getters (a.k.a "format fields")
   IndividualField<Genotype> genotypes() const;                                                                 ///< special getter for the Genotype (GT) field. Returns a random access object with all the values in a given GT tag for all samples contiguous in memory. @warning Only int8_t GT fields have been tested. @warning Missing GT fields are untested. @warning creates a new object but makes no copies of the underlying values.
   IndividualField<IndividualFieldValue<int32_t>> integer_individual_field(const std::string& tag) const;       ///< returns a random access object with all the values in a given individual field tag in integer format for all samples contiguous in memory.  @warning creates a new object but makes no copies of the underlying values.

--- a/gamgee/variant_header.cpp
+++ b/gamgee/variant_header.cpp
@@ -75,6 +75,22 @@ vector<string> VariantHeader::individual_fields() const {
   return find_fields_of_type(m_header.get(), BCF_HL_FMT);
 }
 
+uint8_t VariantHeader::shared_field_type(const std::string& tag) const {
+  return shared_field_type(field_index(tag));
+}
+
+uint8_t VariantHeader::shared_field_type(const int32_t index) const {
+  return bcf_hdr_id2type(m_header.get(), BCF_HL_INFO, index);
+}
+
+uint8_t VariantHeader::individual_field_type(const std::string& tag) const {
+  return individual_field_type(field_index(tag));
+}
+
+uint8_t VariantHeader::individual_field_type(const int32_t index) const {
+  return bcf_hdr_id2type(m_header.get(), BCF_HL_FMT, index);
+}
+
 bool VariantHeader::has_filter(const string& field) const {
   const auto& fields = filters();
   return find(fields.begin(), fields.end(), field) != fields.end();

--- a/gamgee/variant_header.h
+++ b/gamgee/variant_header.h
@@ -37,6 +37,12 @@ class VariantHeader {
   std::vector<std::string> shared_fields() const;     ///< @brief builds a vector with the info fields
   std::vector<std::string> individual_fields() const; ///< @brief builds a vector with the format fields
 
+  // type checking functions: returns BCF_HT_FLAG, BCF_HT_INT, BCF_HT_REAL, BCF_HT_STR from htslib/vcf.h
+  uint8_t shared_field_type(const std::string& tag) const;      ///< returns the type of this shared (INFO) field
+  uint8_t shared_field_type(const int32_t index) const;         ///< returns the type of this shared (INFO) field
+  uint8_t individual_field_type(const std::string& tag) const;  ///< returns the type of this individual (FORMAT) field
+  uint8_t individual_field_type(const int32_t index) const;     ///< returns the type of this individual (FORMAT) field
+
   bool has_filter(const std::string&) const;           ///< @brief checks if the given filter is present
   bool has_shared_field(const std::string&) const;     ///< @brief checks if the given shared (INFO) field is present
   bool has_individual_field(const std::string&) const; ///< @brief checks if the given individual (FORMAT) field is present

--- a/test/variant_reader_test.cpp
+++ b/test/variant_reader_test.cpp
@@ -291,12 +291,12 @@ void check_individual_field_api(const Variant& record, const uint32_t truth_inde
   BOOST_CHECK(as_string != record.individual_field_as_string("PL"));
 
   // check types
-  BOOST_CHECK_EQUAL(record.individual_field_type("GQ"), BCF_HT_INT);
-  BOOST_CHECK_EQUAL(record.individual_field_type("AF"), BCF_HT_REAL);
-  BOOST_CHECK_EQUAL(record.individual_field_type("AS"), BCF_HT_STR);
-  BOOST_CHECK_EQUAL(record.individual_field_type(header.field_index("GQ")), BCF_HT_INT);
-  BOOST_CHECK_EQUAL(record.individual_field_type(header.field_index("AF")), BCF_HT_REAL);
-  BOOST_CHECK_EQUAL(record.individual_field_type(header.field_index("AS")), BCF_HT_STR);
+  BOOST_CHECK_EQUAL(record.header().individual_field_type("GQ"), BCF_HT_INT);
+  BOOST_CHECK_EQUAL(record.header().individual_field_type("AF"), BCF_HT_REAL);
+  BOOST_CHECK_EQUAL(record.header().individual_field_type("AS"), BCF_HT_STR);
+  BOOST_CHECK_EQUAL(record.header().individual_field_type(header.field_index("GQ")), BCF_HT_INT);
+  BOOST_CHECK_EQUAL(record.header().individual_field_type(header.field_index("AF")), BCF_HT_REAL);
+  BOOST_CHECK_EQUAL(record.header().individual_field_type(header.field_index("AS")), BCF_HT_STR);
 
   for(auto i=0u; i != record.n_samples(); ++i) {
     BOOST_CHECK_EQUAL(gq_int[i][0], truth_gq[truth_index][i]);
@@ -399,14 +399,14 @@ void check_shared_field_api(const Variant& record, const uint32_t truth_index) {
   BOOST_CHECK(missing(record.float_shared_field(-1)));  
   BOOST_CHECK(missing(record.string_shared_field(-1))); 
   // type checking
-  BOOST_CHECK_EQUAL(record.shared_field_type("VALIDATED"), BCF_HT_FLAG);
-  BOOST_CHECK_EQUAL(record.shared_field_type("AN"), BCF_HT_INT);
-  BOOST_CHECK_EQUAL(record.shared_field_type("AF"), BCF_HT_REAL);
-  BOOST_CHECK_EQUAL(record.shared_field_type("DESC"), BCF_HT_STR);
-  BOOST_CHECK_EQUAL(record.shared_field_type(header.field_index("VALIDATED")), BCF_HT_FLAG);
-  BOOST_CHECK_EQUAL(record.shared_field_type(header.field_index("AN")), BCF_HT_INT);
-  BOOST_CHECK_EQUAL(record.shared_field_type(header.field_index("AF")), BCF_HT_REAL);
-  BOOST_CHECK_EQUAL(record.shared_field_type(header.field_index("DESC")), BCF_HT_STR);
+  BOOST_CHECK_EQUAL(record.header().shared_field_type("VALIDATED"), BCF_HT_FLAG);
+  BOOST_CHECK_EQUAL(record.header().shared_field_type("AN"), BCF_HT_INT);
+  BOOST_CHECK_EQUAL(record.header().shared_field_type("AF"), BCF_HT_REAL);
+  BOOST_CHECK_EQUAL(record.header().shared_field_type("DESC"), BCF_HT_STR);
+  BOOST_CHECK_EQUAL(record.header().shared_field_type(header.field_index("VALIDATED")), BCF_HT_FLAG);
+  BOOST_CHECK_EQUAL(record.header().shared_field_type(header.field_index("AN")), BCF_HT_INT);
+  BOOST_CHECK_EQUAL(record.header().shared_field_type(header.field_index("AF")), BCF_HT_REAL);
+  BOOST_CHECK_EQUAL(record.header().shared_field_type(header.field_index("DESC")), BCF_HT_STR);
   // check type conversions in the unforgiving API
   BOOST_CHECK_THROW(record.float_shared_field("AN"), runtime_error);
   BOOST_CHECK_THROW(record.string_shared_field("AN"), runtime_error);


### PR DESCRIPTION
This is necessary when merging variants: not all variants will have all fields, but the merged header will

Initially implemented at #261 
