### PR TITLE
ReadGroup class along with some support in SamHeader.

### DIFF
--- a/gamgee/read_group.cpp
+++ b/gamgee/read_group.cpp
@@ -1,0 +1,58 @@
+#include <sstream>
+
+#include <boost/tokenizer.hpp>
+
+#include "read_group.h"
+
+using namespace std;
+using namespace boost;
+
+namespace gamgee {
+
+
+  /**
+   * @brief creates and populates a read group object from a sam header line
+   *
+   * @note A read group line in a SAM header starts with "@RG" and then has tag/value
+   * pairs separated by whitespace.  The tags are all length-2 strings and the tags are
+   * separated from values by colons.  Ex: @RG   ID:12345.67   SM:11111  PL:Illumina
+   */
+  ReadGroup::ReadGroup(const std::string& header_line) {
+    const static auto CHARACTERS_PER_TAG = 2;
+    const static auto RG_TAG_LENGTH = 3;
+    const static auto TAB_SEPARATOR = char_separator<char>("\t");
+
+    auto fields = header_line.substr(RG_TAG_LENGTH+1);  //skip the @RG tag
+    auto tokens = tokenizer<char_separator<char>>(fields, TAB_SEPARATOR);
+    for ( const auto& token : tokens) {
+      //we skip 3 characters -- 2 for the tag, 1 for the colon
+      auto value = token.substr(CHARACTERS_PER_TAG+1, token.length() - CHARACTERS_PER_TAG - 1);
+      if      ( starts_with(token, ID_TAG) )                  id = value;
+      else if ( starts_with(token, SAMPLE_TAG) )              sample = value;
+      else if ( starts_with(token, CENTER_TAG) )              center = value;
+      else if ( starts_with(token, DESCRIPTION_TAG) )         description = value;
+      else if ( starts_with(token, DATE_TIME_TAG) )           date_time = value;
+      else if ( starts_with(token, CENTER_TAG) )              center = value;
+      else if ( starts_with(token, FLOW_ORDER_TAG) )          flow_order = value;
+      else if ( starts_with(token, KEY_SEQUENCE_TAG) )        key_sequence = value;
+      else if ( starts_with(token, LIBRARY_TAG) )             library = value;
+      else if ( starts_with(token, PROGRAMS_TAG) )            programs = value;
+      else if ( starts_with(token, MEDIAN_INSERT_SIZE_TAG) )  median_insert_size = value;
+      else if ( starts_with(token, PLATFORM_TAG) )            platform = value;
+      else if ( starts_with(token, PLATFORM_UNIT_TAG) )       platform_unit = value;
+    }
+  }
+
+  const char ReadGroup::ID_TAG [3] = "ID";
+  const char ReadGroup::CENTER_TAG [3] = "CN";
+  const char ReadGroup::DESCRIPTION_TAG [3] = "DS";
+  const char ReadGroup::DATE_TIME_TAG [3] = "DT";
+  const char ReadGroup::FLOW_ORDER_TAG [3] = "FO";
+  const char ReadGroup::KEY_SEQUENCE_TAG [3] = "KS";
+  const char ReadGroup::LIBRARY_TAG [3] = "LB";
+  const char ReadGroup::PROGRAMS_TAG [3] = "PG";
+  const char ReadGroup::MEDIAN_INSERT_SIZE_TAG [3] = "PI";
+  const char ReadGroup::PLATFORM_TAG [3] = "PL";
+  const char ReadGroup::PLATFORM_UNIT_TAG [3] = "PU";
+  const char ReadGroup::SAMPLE_TAG [3] = "SM";
+}

--- a/gamgee/read_group.h
+++ b/gamgee/read_group.h
@@ -1,0 +1,60 @@
+#ifndef gamgee__read_group__guard
+#define gamgee__read_group__guard
+
+#include<string>
+
+namespace gamgee {
+
+
+  /**
+   * @brief Helper struct to hold one read group record from a sam file header
+   *
+   * A read group, which is contained in a line starting with "@RG" in a sam file header,
+   * contains information about the seuencing process: type of machine, time, center etc.
+   * Most important for variant calling and quality control is the sample ID -- each sample
+   * may be split into several read groups.
+   */
+  class ReadGroup {
+
+  public:
+    std::string id;
+    std::string center;
+    std::string description;
+    std::string date_time;
+    std::string flow_order;
+    std::string key_sequence;
+    std::string library;
+    std::string programs;
+    std::string median_insert_size;
+    std::string platform;
+    std::string platform_unit;
+    std::string sample;
+
+    ReadGroup() = default;
+    ReadGroup(const std::string& header_line);
+
+  private:
+    static const char ID_TAG [];
+    static const char CENTER_TAG [];
+    static const char DESCRIPTION_TAG [];
+    static const char DATE_TIME_TAG [];
+    static const char FLOW_ORDER_TAG [];
+    static const char KEY_SEQUENCE_TAG [];
+    static const char LIBRARY_TAG [];
+    static const char PROGRAMS_TAG [];
+    static const char MEDIAN_INSERT_SIZE_TAG [];
+    static const char PLATFORM_TAG [];
+    static const char PLATFORM_UNIT_TAG [];
+    static const char SAMPLE_TAG [];
+
+    static bool starts_with(const std::string& token, const char tag[2]) {
+        return token[0] == tag[0] && token[1] == tag[1];
+    }
+  };
+
+
+}
+
+
+
+#endif //gamgee__read_group__guard

--- a/gamgee/sam_header.cpp
+++ b/gamgee/sam_header.cpp
@@ -50,4 +50,21 @@ namespace gamgee {
 	  return 0;
   }
 
+  /**
+   * @brief extracts read group objects from a SAM header
+   */
+  vector<ReadGroup> SamHeader::read_groups() const {
+    const static auto RG_TAG = "@RG";
+    const static auto NOT_FOUND = string::npos;
+    auto result = vector<ReadGroup>();
+    auto text = header_text();
+
+    for (auto rg_start=text.find(RG_TAG), rg_end=rg_start; rg_start!=NOT_FOUND; rg_start=text.find(RG_TAG,rg_end+1) ) {
+      rg_end = text.find('\n', rg_start+1);
+      auto rg_record = text.substr(rg_start, rg_end-rg_start);
+      result.push_back(ReadGroup(rg_record));
+    }
+    return result;
+  }
+
 }

--- a/gamgee/sam_header.h
+++ b/gamgee/sam_header.h
@@ -2,9 +2,11 @@
 #define gamgee__sam_header__guard
 
 #include "htslib/sam.h"
+#include "read_group.h"
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace gamgee {
 
@@ -23,8 +25,10 @@ class SamHeader {
   uint32_t sequence_length(const std::string& sequence_name) const; ///< @brief Returns the length of the given reference sequence as stored in the \@SQ tag in the BAM header.
   uint32_t sequence_length(const uint32_t sequence_index) const { return m_header->target_len[sequence_index]; }                ///< @brief Returns the length of the given reference sequence as stored in the \@SQ tag in the BAM header.
   std::string sequence_name(const uint32_t sequence_index) const { return std::string(m_header->target_name[sequence_index]); } ///< @brief Returns the sequence name for the sequence with the given zero-based index
+  std::vector<ReadGroup> read_groups() const;
 
  private:
+  std::string header_text() const { return std::string(m_header->text, m_header->l_text); } ///< @brief Returns the text of the SAM header for parsing as an std::string. @note htslib only parses @SQ records, so gamgee is not simply a wrapper for C code.
   std::shared_ptr<bam_hdr_t> m_header;
 
   friend class SamWriter;

--- a/test/read_group_test.cpp
+++ b/test/read_group_test.cpp
@@ -1,0 +1,31 @@
+#include <string>
+
+#include <boost/test/unit_test.hpp>
+
+#include "read_group.h"
+
+
+using namespace std;
+using namespace gamgee;
+using namespace boost;
+
+BOOST_AUTO_TEST_CASE( simple_record_test ) {
+  auto record = string{"@RG\tID:12345\tPL:Illumina\tSM:#$%^"};
+  auto rg = ReadGroup(record);
+  BOOST_CHECK_EQUAL(rg.id, "12345");
+  BOOST_CHECK_EQUAL(rg.sample, "#$%^");
+  BOOST_CHECK_EQUAL(rg.platform, "Illumina");
+  BOOST_CHECK_EQUAL(rg.center, "");
+}
+
+BOOST_AUTO_TEST_CASE( strange_punctuation_test) {
+  auto record = string{"@RG\tID:lalala:lalala\tPL:Spiffy new platform"};
+  auto rg = ReadGroup(record);
+  BOOST_CHECK_EQUAL(rg.id, "lalala:lalala");
+  BOOST_CHECK_EQUAL(rg.platform, "Spiffy new platform");
+}
+
+BOOST_AUTO_TEST_CASE(user_defined_field_test) {
+  auto record = string{"@RG\txy:xxxx\tab:aaaa"};
+  auto rg = ReadGroup(record);
+}

--- a/test/sam_header_test.cpp
+++ b/test/sam_header_test.cpp
@@ -16,6 +16,16 @@ BOOST_AUTO_TEST_CASE( sam_header ) {
   BOOST_CHECK_EQUAL(1u, header.n_sequences());
 }
 
+BOOST_AUTO_TEST_CASE( sam_header_read_groups ) {
+  auto reader = SingleSamReader{"testdata/test_simple.bam"};
+  auto header = reader.header();
+  auto rgs = header.read_groups();
+  BOOST_CHECK_EQUAL(1u, rgs.size());
+  BOOST_CHECK_EQUAL(rgs[0].id, "exampleBAM.bam");
+  BOOST_CHECK_EQUAL(rgs[0].platform, "illumina");
+  BOOST_CHECK_EQUAL(rgs[0].library, "exampleBAM.bam");
+}
+
 /** @todo Need a way to modify the header in between these copies/moves to make sure these are working properly! */
 BOOST_AUTO_TEST_CASE( sam_header_constructors ) {
   auto reader = SingleSamReader{"testdata/test_simple.bam"};


### PR DESCRIPTION
ReadGroup is a simple class for storing a read group (@RG) record from a SAM header.  This commit also adds a method in SamHeader that parses the header text and gets a vector of ReadGroups.
