### PR TITLE
Verified that IndividualFieldValue::missing() is now working after Karthik's vector end changes

### DIFF
--- a/gamgee/individual_field_value.h
+++ b/gamgee/individual_field_value.h
@@ -170,10 +170,12 @@ class IndividualFieldValue {
    * @brief returns true if all of the values are missing
    */
   bool missing() const {
-    for (const auto value : *this)
+    // Important: relies on IndividualFieldValueIterator to skip vector end values, if there are any
+    for (const auto& value : *this) {
       // use qualifier to avoid recursion
       if (!gamgee::missing(value))
         return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
Turns out that IndividualFieldValue::missing() now works after Karthik's
changes to IndividualFieldValueIterator to skip vector end values.

Added a comment explaining why it now works, and also added tests to confirm
that it works.

I hope that I am starting a new tradition here of putting new Variant-related tests
in variant_test.cpp as small, independent test cases instead of adding to the
awful, monolithic, intertwined tests in variant_reader_test.cpp. VariantBuilder
should help a lot with constructing specific test cases (as it did here).

Resolves #305
