### PR TITLE
A missing() function for the Variant class

### DIFF
--- a/gamgee/variant.h
+++ b/gamgee/variant.h
@@ -35,6 +35,7 @@ class Variant {
   Variant& operator=(Variant&& other) = default;                                                              ///< move assignment of a Variant and it's header. Shared pointers maintain state to all other associated objects correctly.
 
   VariantHeader header() const { return VariantHeader{m_header}; }
+  bool missing() const { return m_body == nullptr; }                 ///< returns true if this is a default-constructed Variant object with no data
 
   uint32_t chromosome()         const {return uint32_t(m_body->rid);}                                         ///< returns the integer representation of the chromosome. Notice that chromosomes are listed in index order with regards to the header (so a 0-based number). Similar to Picards getReferenceIndex()
   std::string chromosome_name() const {return header().chromosomes()[chromosome()];}                          ///< returns the name of the chromosome by querying the header.

--- a/test/variant_test.cpp
+++ b/test/variant_test.cpp
@@ -1,8 +1,9 @@
 #include <boost/test/unit_test.hpp>
 #include "variant_reader.h"
 #include "variant.h"
-#include "utils/variant_utils.h"
 #include "variant_builder.h"
+#include "missing.h"
+#include "utils/variant_utils.h"
 
 using namespace std;
 using namespace gamgee;
@@ -45,6 +46,17 @@ BOOST_AUTO_TEST_CASE( allele_mask_snp_and_insertion ) {
   BOOST_CHECK(am[0] == AlleleType::REFERENCE);
   BOOST_CHECK(am[1] == AlleleType::DELETION);
   BOOST_CHECK(am[2] == AlleleType::INSERTION);
+}
+
+BOOST_AUTO_TEST_CASE( test_missing_variant_record ) {
+  auto header = SingleVariantReader{"testdata/test_variants.vcf"}.header();
+  auto builder = VariantBuilder{header};
+
+  auto missing_variant = Variant{};
+  auto non_missing_variant = builder.set_chromosome("20").set_alignment_start(5).set_ref_allele("A").build();
+
+  BOOST_CHECK(missing(missing_variant));
+  BOOST_CHECK(! missing(non_missing_variant));
 }
 
 BOOST_AUTO_TEST_CASE( test_missing_integer_individual_field_values ) {


### PR DESCRIPTION
Sometimes we need to distinguish blank, default-constructed Variant
objects from Variant objects with data. This change allows us to do so
via the standard gamgee::missing() convention.
