### PR TITLE
Travis: add prebuilt cmake 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   - sudo apt-get -qq update;
 
 install:
+  - .travis_scripts/cmake.sh
   - .travis_scripts/boost.sh
   - if [ "$CXX" == "clang++" ]; then .travis_scripts/clang.sh; fi
   - if [ "$CXX" == "g++"     ]; then .travis_scripts/gcc.sh; fi

--- a/.travis_scripts/cmake.sh
+++ b/.travis_scripts/cmake.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+wget http://www.broadinstitute.org/~carneiro/travis/cmake_3.1.0-rc1-1_amd64.deb
+sudo apt-get remove cmake cmake-data
+sudo dpkg --install cmake_3.1.0-rc1-1_amd64.deb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,10 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 project(gamgee)
 
 include(ExternalProject)
 
-## This is the right way to do this, but only supported in cmake 2.8.12
-#add_compile_options("-std=c++1y")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y")
+# This is a C++14 library
+add_compile_options("-std=c++1y")
 
 # Dependency: Boost Unit Test Framework (find in the system)
 find_package(Boost 1.55 COMPONENTS unit_test_framework REQUIRED)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,9 +23,7 @@ set(SOURCE_FILES
 
 add_executable(gamgee_test EXCLUDE_FROM_ALL ${SOURCE_FILES})
 
-## This is the right way to do this, but only supported in cmake 2.8.12
-# target_compile_definitions(gamgee_test PUBLIC -DBOOST_TEST_DYN_LINK)
-set_property(TARGET gamgee_test PROPERTY COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK)
+target_compile_definitions(gamgee_test PUBLIC -DBOOST_TEST_DYN_LINK)
 target_link_libraries(gamgee_test gamgee ${htslib_LIB} ${Boost_LIBRARIES} pthread z)
 add_dependencies(gamgee_test htslib)
 


### PR DESCRIPTION
I got on a Travis VM and built a binary package for the latest version of cmake. Now we can use all the nice functionality. 
- update the commented out code that was only for 2.8.7
