### PR TITLE
Eliminate duplication of VariantHeader functionality in Variant class

### DIFF
--- a/gamgee/variant_header.cpp
+++ b/gamgee/variant_header.cpp
@@ -124,20 +124,4 @@ uint32_t VariantHeader::n_individual_fields() const {
   return count_fields_of_type(m_header.get(), BCF_HL_FMT);
 }
 
-uint8_t VariantHeader::shared_field_type(const std::string& tag) const {
-  return shared_field_type(field_index(tag));
-}
-
-uint8_t VariantHeader::shared_field_type(const int32_t index) const {
-  return bcf_hdr_id2type(m_header.get(), BCF_HL_INFO, index);
-}
-
-uint8_t VariantHeader::individual_field_type(const std::string& tag) const {
-  return individual_field_type(field_index(tag));
-}
-
-uint8_t VariantHeader::individual_field_type(const int32_t index) const {
-  return bcf_hdr_id2type(m_header.get(), BCF_HL_FMT, index);
-}
-
 }

--- a/test/variant_header_test.cpp
+++ b/test/variant_header_test.cpp
@@ -73,6 +73,26 @@ void variant_header_builder_checks(const VariantHeader& vh) {
   BOOST_CHECK(! vh.has_individual_field(vh.field_index("LOW_QUAL")));
   BOOST_CHECK(! vh.has_individual_field(20));
 
+  // Also test API functions that take an explicit field category as a parameter (BCF_HL_INFO, etc.)
+  BOOST_CHECK(vh.has_field("MQ", BCF_HL_INFO));
+  BOOST_CHECK(vh.has_field(vh.field_index("MQ"), BCF_HL_INFO));
+  BOOST_CHECK(! vh.has_field("BLAH", BCF_HL_INFO));
+  BOOST_CHECK(! vh.has_field(vh.field_index("BLAH"), BCF_HL_INFO));
+  BOOST_CHECK(vh.has_field("GQ", BCF_HL_FMT));
+  BOOST_CHECK(vh.has_field(vh.field_index("GQ"), BCF_HL_FMT));
+  BOOST_CHECK(! vh.has_field("BLAH", BCF_HL_FMT));
+  BOOST_CHECK(! vh.has_field(vh.field_index("BLAH"), BCF_HL_FMT));
+
+  // Test type-querying functions (note: these assume that you've already checked field existence)
+  BOOST_CHECK_EQUAL(vh.shared_field_type("MQ"), BCF_HT_INT);
+  BOOST_CHECK_EQUAL(vh.shared_field_type(vh.field_index("MQ")), BCF_HT_INT);
+  BOOST_CHECK_EQUAL(vh.field_type("MQ", BCF_HL_INFO), BCF_HT_INT);
+  BOOST_CHECK_EQUAL(vh.field_type(vh.field_index("MQ"), BCF_HL_INFO), BCF_HT_INT);
+  BOOST_CHECK_EQUAL(vh.individual_field_type("PL"), BCF_HT_REAL);
+  BOOST_CHECK_EQUAL(vh.individual_field_type(vh.field_index("PL")), BCF_HT_REAL);
+  BOOST_CHECK_EQUAL(vh.field_type("PL", BCF_HL_FMT), BCF_HT_REAL);
+  BOOST_CHECK_EQUAL(vh.field_type(vh.field_index("PL"), BCF_HL_FMT), BCF_HT_REAL);
+
   BOOST_CHECK(vh.has_sample("S1"));
   BOOST_CHECK(vh.has_sample(vh.sample_index("S1")));
   BOOST_CHECK(vh.has_sample("S292"));


### PR DESCRIPTION
Make Variant's m_header member a full VariantHeader instead of a raw htslib
pointer so that Variant can take advantage of the existing VariantHeader
API functions instead of duplicating them. Remove duplicated VariantHeader
functionality from Variant.

Also made some formerly private VariantHeader functions public in order
to allow you to query field existence / type and pass the field category
(info, format, or filter) as a parameter.

Also improved test coverage for the VariantHeader API

Resolves #286
