### PR TITLE
Update gamgee to work with revved version of htslib

### DIFF
--- a/gamgee/utils/variant_utils.cpp
+++ b/gamgee/utils/variant_utils.cpp
@@ -24,6 +24,8 @@ void subset_variant_samples(bcf_hdr_t* hdr_ptr, const std::vector<std::string>& 
     sample_list.erase(sample_list.size() - 1);
     bcf_hdr_set_samples(hdr_ptr, sample_list.c_str(), false);
   }
+
+  // NOTE: must NOT call bcf_hdr_sync() here, since htslib calls it for us in bcf_hdr_set_samples()
 }
 
 void merge_variant_headers(const std::shared_ptr<bcf_hdr_t>& dest_hdr_ptr, const std::shared_ptr<bcf_hdr_t>& src_hdr_ptr) {
@@ -39,6 +41,7 @@ void merge_variant_headers(const std::shared_ptr<bcf_hdr_t>& dest_hdr_ptr, const
 
   // vcf.h    "After all samples have been added, NULL must be passed to update internal header structures."
   bcf_hdr_add_sample(dest_hdr_ptr.get(), nullptr);
+  bcf_hdr_sync(dest_hdr_ptr.get());
 }
 
 }

--- a/gamgee/variant.h
+++ b/gamgee/variant.h
@@ -176,8 +176,8 @@ class Variant {
 
   bcf_fmt_t*  find_individual_field(const std::string& tag) const { return bcf_get_fmt(m_header.m_header.get(), m_body.get(), tag.c_str());  }
   bcf_info_t* find_shared_field(const std::string& tag)     const { return bcf_get_info(m_header.m_header.get(), m_body.get(), tag.c_str()); }
-  bcf_fmt_t*  find_individual_field(const uint32_t index) const { return bcf_get_fmt_idx(m_body.get(), index);                    }
-  bcf_info_t* find_shared_field(const uint32_t index)     const { return bcf_get_info_idx(m_body.get(), index);                   }
+  bcf_fmt_t*  find_individual_field(const uint32_t index) const { return bcf_get_fmt_id(m_body.get(), index); }
+  bcf_info_t* find_shared_field(const uint32_t index)     const { return bcf_get_info_id(m_body.get(), index); }
   bool check_field(const int32_t type_field, const int32_t type_value, const int32_t index) const;
   inline AlleleType allele_type_from_difference(const int diff) const;
 

--- a/gamgee/variant_header_builder.h
+++ b/gamgee/variant_header_builder.h
@@ -58,6 +58,8 @@ class VariantHeaderBuilder {
    * @brief create a new VariantHeader by copying the contents of this builder into a new object.  Allows for reuse.
    */
   VariantHeader build() const {
+    // Need to sync the header before returning it so that changes will be reflected in the final product
+    bcf_hdr_sync(m_header.get());
     return VariantHeader{utils::make_shared_variant_header(utils::variant_header_deep_copy(m_header.get()))};
   }
 
@@ -65,7 +67,11 @@ class VariantHeaderBuilder {
    * @brief create a new VariantHeader by moving the contents of this builder into a new object.
    * More efficient but does not allow for reuse.
    */
-  VariantHeader one_time_build() const { return VariantHeader{move(m_header)}; }
+  VariantHeader one_time_build() const {
+    // Need to sync the header before returning it so that changes will be reflected in the final product
+    bcf_hdr_sync(m_header.get());
+    return VariantHeader{move(m_header)};
+  }
 
  private:
   std::shared_ptr<bcf_hdr_t> m_header;


### PR DESCRIPTION
We just updated our htslib fork with the last 3 months' worth of changes
from upstream. A few things in gamgee broke as a result and needed to be
fixed:

-Updated a few htslib API calls in gamgee whose names had changed in upstream

-Sync variant headers in VariantHeaderBuilder when building headers

htslib no longer calls bcf_hdr_sync() for us each time we modify
a variant header, so we need to call it ourselves in VariantHeaderBuilder
at build time

-Sync variant headers when merging multiple headers

Another consequence of htslib's new, lazier approach to variant
header synchronization: we need to explicitly call bcf_hdr_sync()
when merging variant headers
