### PR TITLE
Remove obsolete call in merge_variant_headers()

### DIFF
--- a/gamgee/utils/variant_utils.cpp
+++ b/gamgee/utils/variant_utils.cpp
@@ -38,9 +38,7 @@ void merge_variant_headers(const std::shared_ptr<bcf_hdr_t>& dest_hdr_ptr, const
     // don't check for error code because the only "error" is ignoring a duplicate sample, not an error for us
     bcf_hdr_add_sample(dest_hdr_ptr.get(), src_hdr_ptr->samples[sample_counter]);
   }
-
-  // vcf.h    "After all samples have been added, NULL must be passed to update internal header structures."
-  bcf_hdr_add_sample(dest_hdr_ptr.get(), nullptr);
+  
   bcf_hdr_sync(dest_hdr_ptr.get());
 }
 


### PR DESCRIPTION
Now that htslib expects us to sync headers manually, we don't
need to pass in a nullptr when we're done adding samples to
a header

Resolves #363
