### PR TITLE
Prevent vector end values from getting transformed during Genotype encoding, and detect invalid values

### DIFF
--- a/gamgee/genotype.h
+++ b/gamgee/genotype.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <utility>
+#include <stdexcept>
 
 namespace gamgee {
 
@@ -296,7 +297,14 @@ class Genotype{
    */
   static inline void encode_genotype(std::vector<int32_t>& alleles, bool phase_all_alleles) {
     for ( auto allele_index = 0u; allele_index < alleles.size(); ++allele_index ) {
-      alleles[allele_index] = (alleles[allele_index] + 1) << 1 | (phase_all_alleles && allele_index > 0u ? 1 : 0);
+      // Only legal value below -1 is the int32 vector end value
+      if ( alleles[allele_index] < -1 && alleles[allele_index] != bcf_int32_vector_end ) {
+        throw std::invalid_argument{"Genotype vector must consist only of allele indices, -1 for missing values, or vector end values"};
+      }
+      // Do not modify vector end values
+      else if ( alleles[allele_index] != bcf_int32_vector_end ) {
+        alleles[allele_index] = (alleles[allele_index] + 1) << 1 | (phase_all_alleles && allele_index > 0u ? 1 : 0);
+      }
     }
   }
 

--- a/test/variant_builder_test.cpp
+++ b/test/variant_builder_test.cpp
@@ -1112,10 +1112,17 @@ BOOST_AUTO_TEST_CASE( bulk_set_genotype_field ) {
     check_genotype_field(variant, expected);
 
     // Flat vector, varying ploidy with manual padding
-    flat_vector = {0, 1, 2, 1, 0, -1, 0, -1, -1}; Genotype::encode_genotype(flat_vector);
-    expected = {{0, 1, 2}, {1, 0, missing_values::int32}, {0, missing_values::int32, missing_values::int32}};
+    flat_vector = {0, 1, 2, 1, bcf_int32_vector_end, bcf_int32_vector_end, 0, 1, bcf_int32_vector_end}; Genotype::encode_genotype(flat_vector);
+    expected = {{0, 1, 2}, {1, bcf_int32_vector_end, bcf_int32_vector_end}, {0, 1, bcf_int32_vector_end}};
     variant = perform_move ? builder.set_genotypes(move(flat_vector)).build() :
                              builder.set_genotypes(flat_vector).build();
+    check_genotype_field(variant, expected);
+
+    // Flat vector, varying ploidy with manual padding and a missing sample
+    flat_vector = {0, 1, 2, -1, bcf_int32_vector_end, bcf_int32_vector_end, 0, 1, bcf_int32_vector_end}; Genotype::encode_genotype(flat_vector);
+    expected = {{0, 1, 2}, {bcf_int32_missing, bcf_int32_vector_end, bcf_int32_vector_end}, {0, 1, bcf_int32_vector_end}};
+    variant = perform_move ? builder.set_genotypes(move(flat_vector)).build() :
+              builder.set_genotypes(flat_vector).build();
     check_genotype_field(variant, expected);
 
     // Nested vector, one allele per sample


### PR DESCRIPTION
Previously we were incorrectly encoding vector end values in Genotype::encode_genotype().
Now vector end values are skipped, and invalid values are detected (only allele indices
>= 0, -1 for missing genotypes, and vector end values are allowed).
