### PR TITLE
Added LUT for merged header in MultipleVariantReader

### DIFF
--- a/gamgee/CMakeLists.txt
+++ b/gamgee/CMakeLists.txt
@@ -29,6 +29,8 @@ set(SOURCE_FILES
     multiple_variant_iterator.cpp
     multiple_variant_iterator.h
     multiple_variant_reader.h
+    variant_header_merger.h
+    variant_header_merger.cpp
     read_bases.cpp
     read_bases.h
     read_group.cpp
@@ -73,6 +75,8 @@ set(SOURCE_FILES
     utils/variant_field_type.h
     utils/variant_utils.cpp
     utils/variant_utils.h
+    utils/merged_vcf_lut.h
+    utils/merged_vcf_lut.cpp
     variant_builder.cpp
     variant_builder.h
     variant_builder_individual_field.h

--- a/gamgee/gamgee.h
+++ b/gamgee/gamgee.h
@@ -58,5 +58,7 @@
 #include "variant_reader.h"
 #include "variant_writer.h"
 #include "zip.h"
+#include "utils/merged_vcf_lut.h"
+#include "variant_header_merger.h"
 
 #endif  /* gamgee__gamgee__guard */

--- a/gamgee/utils/merged_vcf_lut.cpp
+++ b/gamgee/utils/merged_vcf_lut.cpp
@@ -1,0 +1,87 @@
+#include "merged_vcf_lut.h"
+
+using namespace std;
+namespace gamgee
+{
+  namespace utils
+  {
+    template<bool inputs_2_merged_LUT_is_input_ordered, bool merged_2_inputs_LUT_is_input_ordered>
+    MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>::MergedVCFLUTBase()
+    {
+      m_num_input_vcfs = 0u;
+      m_num_merged_fields = 0u;
+      clear();
+    }
+
+    template<bool inputs_2_merged_LUT_is_input_ordered, bool merged_2_inputs_LUT_is_input_ordered>
+    MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>::MergedVCFLUTBase(unsigned numInputGVCFs, unsigned numMergedFields)
+    {
+      m_num_input_vcfs = numInputGVCFs;
+      m_num_merged_fields = numMergedFields;
+      clear();
+      resize_inputs_2_merged_lut_if_needed(numInputGVCFs, numMergedFields);
+      resize_merged_2_inputs_lut_if_needed(numInputGVCFs, numMergedFields);
+    }
+
+    template<bool inputs_2_merged_LUT_is_input_ordered, bool merged_2_inputs_LUT_is_input_ordered>
+    void MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>::clear()
+    {
+      for(auto& vec : m_inputs_2_merged_lut)
+	vec.clear();
+      m_inputs_2_merged_lut.clear();
+      for(auto& vec : m_merged_2_inputs_lut)
+	vec.clear();
+      m_merged_2_inputs_lut.clear();
+    }
+
+    template<bool inputs_2_merged_LUT_is_input_ordered, bool merged_2_inputs_LUT_is_input_ordered>
+    void MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>::reset_vector(vector<int>& vec, unsigned from)
+    {
+      for(auto i=from;i<vec.size();++i)
+	vec[i] = gamgee::missing_values::int32;
+    }
+
+    template<bool inputs_2_merged_LUT_is_input_ordered, bool merged_2_inputs_LUT_is_input_ordered>
+    void MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>::resize_and_reset_vector(vector<int>& vec, unsigned new_size)
+    {
+      auto old_size = vec.size();
+      if(new_size > old_size)
+      {
+	vec.resize(new_size);
+	reset_vector(vec, old_size);
+      }
+    }
+
+    template<bool inputs_2_merged_LUT_is_input_ordered, bool merged_2_inputs_LUT_is_input_ordered>
+    void MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>::resize_and_reset_lut
+    (vector<vector<int>>& lut, unsigned new_lut_size, unsigned new_vector_size, unsigned& numRowsVar, unsigned& numColsVar)
+    {
+      auto old_lut_size = lut.size();
+      if(new_lut_size > old_lut_size)
+      {
+	lut.resize(new_lut_size);
+	numRowsVar = new_lut_size;
+      }
+      auto old_vector_size = (lut.size() > 0u) ? lut[0].size() : 0u;
+      //Begin resizing of vectors at start_idx
+      auto start_idx = old_lut_size;
+      if(new_vector_size > old_vector_size)	//every vector needs to be resized
+      {
+	start_idx = 0u;
+	numColsVar = new_vector_size;
+      }
+      else
+	new_vector_size = old_vector_size;	//new vector size is smaller, don't bother reducing the size of existing rows
+      for(auto i=start_idx;i<new_lut_size;++i)
+	resize_and_reset_vector(lut[i], new_vector_size);
+    }
+    //explicit initialization to avoid link errors
+    template class MergedVCFLUTBase<true,true>;
+    template class MergedVCFLUTBase<true,false>;
+    template class MergedVCFLUTBase<false,true>;
+    template class MergedVCFLUTBase<false,false>;
+
+    //explicit initialization to avoid link errors
+    template class MergedVCFAllelesIdxLUT<true,true>;
+  }
+}

--- a/gamgee/utils/merged_vcf_lut.h
+++ b/gamgee/utils/merged_vcf_lut.h
@@ -1,0 +1,303 @@
+#ifndef __gamgee_merged_vcf_lut__
+#define __gamgee_merged_vcf_lut__
+
+#include<assert.h>
+
+#include "htslib/vcf.h"
+#include <vector>
+#include "variant_header.h"
+#include "missing.h"
+
+
+//forward declaration for friend function of MergedVCFLUTBase
+template<bool inputs_2_merged_LUT_is_input_ordered, bool merged_2_inputs_LUT_is_input_ordered>
+void test_lut_base();
+
+namespace gamgee
+{
+  //forward declaration of friend class of MergedVCFLUTBase
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  class VariantHeaderMerger;
+
+  namespace utils
+  {
+    /**
+     * LUT = Look Up Table (to avoid confusion with map, unordered_map etc)
+     * @brief Base class to store look up information between fields of merged header and input headers
+     * @note This is the helper class for VariantHeaderMerger to store mapping for fields and samples
+     * Each MergedVCFLUTBase object contains 2 matrices (vector of vector): one for mapping input field idx to merged field idx (m_inputs_2_merged_lut)
+     * and the second for mapping merged field idx to input field idx (m_merged_2_inputs_lut).
+     *
+     * Missing field information is stored as bcf_int32_missing, but should be checked with gamgee::missing() function
+     * 
+     * The boolean template parameters specify how the 2 tables are laid out in memory - whether the outer vector corresponds to fields or input vcfs.
+     * For example, in object of type MergedVCFLUTBase<true, true>, both LUTs are laid out such that m_inputs_2_merged_lut[0] contains mappings 
+     * for all fields for input VCF file 0. This would lead to fast traversal of all fields for a given input VCF (cache locality). 
+     * However, traversing over all input VCFs for a given field would be slow (many cache misses).
+     * The object MergedVCFLUTBase<false,false> would have the exact opposite behavior
+     * 
+     * The 'best' value of the template parameters depends on the application using the LUT.
+     * Almost all the 'complexity' of the code comes from being able to handle the different layouts in a transparent manner
+     *
+     * Alternate explanation:
+     * This class contains two matrices (vector<vector<int>>) to store the mapping information:
+     * m_inputs_2_merged_lut and m_merged_2_inputs_lut. You can layout each matrix in one of the 2 following ways:
+     * (a) LUT[i][j]  corresponds to input VCF i and field j 
+     * (b) LUT[i][j]  corresponds to field i and input VCF j
+     * Option (a) is optimal where you are looking at all the fields of a VCF in quick succession,
+     * while (b) is optimal when you are looking at all VCFs for a particular field.
+     * The 2 boolean template parameters control the layout of the two matrices. If the parameter value is true,
+     * then option (a) is picked, else option (b)
+     *
+     * Although the class provides functions to resize the tables, for obtaining good performance, reallocations should be extremely
+     * infrequent. Making the resize_luts_if_needed() a protected member forces developers to think twice instead of blindly calling this function.
+     *
+     * Uses the enable_if trick from http://en.cppreference.com/w/cpp/types/enable_if  (foo3) to handle different memory layouts
+     * 
+     **/
+    template<bool inputs_2_merged_LUT_is_input_ordered, bool merged_2_inputs_LUT_is_input_ordered>
+    class MergedVCFLUTBase
+    {
+      template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+      friend class gamgee::VariantHeaderMerger;
+      template<bool v1, bool v2>
+      friend void ::test_lut_base();
+      public:
+      /**
+       * @brief: clear all mappings
+       */
+      inline void reset_luts()
+      {
+	for(auto& vec : m_inputs_2_merged_lut)
+	  reset_vector(vec);
+	for(auto& vec : m_merged_2_inputs_lut)
+	  reset_vector(vec);
+      }
+
+      /*
+       * @brief Add a valid mapping between input VCF and merged VCF
+       * @note all parameters should be valid parameters, no bcf_int32_missing allowed, use reset_() functions to invalidate existing mapping
+       * @param inputGVCFIdx index of the input VCF file
+       * @param inputIdx index of the field in the input VCF file - field could be anything header field,sample,allele etc
+       * @param mergedIdx index of the field in the merged VCF file
+       */
+      inline void add_input_merged_idx_pair(unsigned inputGVCFIdx, int inputIdx, int mergedIdx)
+      {
+	set_merged_idx_for_input(inputGVCFIdx, inputIdx, mergedIdx);
+	set_input_idx_for_merged(inputGVCFIdx, inputIdx, mergedIdx);
+      }
+
+      /**
+       * @brief Get field idx for input VCF inputGVCFIdx corresponding to field idx mergedIdx in the mergedVCF file
+       * @note Uses the enable_if trick from http://en.cppreference.com/w/cpp/types/enable_if  (foo3) to handle different memory layouts
+       * The enable_if<M> corresponds to the case where merged_2_inputs_LUT_is_input_ordered = true, hence, the rows correspond to input VCFs
+       * The enable_if<!M> corresponds to the case where merged_2_inputs_LUT_is_input_ordered = false, hence, the rows correspond to fields
+       * @param inputGVCFIdx index of the input VCF file
+       * @param mergedIdx index of the field in the merged VCF file
+       * @return index of the field in the input VCF file
+       */
+      template <bool M = merged_2_inputs_LUT_is_input_ordered, typename std::enable_if<M>::type* = nullptr>
+      inline int get_input_idx_for_merged(unsigned inputGVCFIdx, int mergedIdx) const
+      { return get_lut_value(m_merged_2_inputs_lut, inputGVCFIdx, mergedIdx); }
+      template <bool M = merged_2_inputs_LUT_is_input_ordered, typename std::enable_if<!M>::type* = nullptr>
+      inline int get_input_idx_for_merged(unsigned inputGVCFIdx, int mergedIdx) const
+      { return get_lut_value(m_merged_2_inputs_lut, mergedIdx, inputGVCFIdx); }
+
+      /**
+       * @brief Get field idx for the merged VCF corresponding to field idx inputIdx in the input VCF of index inputGVCFIdx
+       * @note Uses the enable_if trick from http://en.cppreference.com/w/cpp/types/enable_if  (foo3) to handle different memory layouts
+       * The enable_if<M> corresponds to the case where inputs_2_merged_LUT_is_input_ordered = true, hence, the rows correspond to input VCFs
+       * The enable_if<!M> corresponds to the case where inputs_2_merged_LUT_is_input_ordered = false, hence, the rows correspond to fields
+       * @param inputGVCFIdx index of the input VCF file
+       * @param inputIdx index of the field in the input VCF file
+       * @return index of the field in the merged VCF file
+       */
+      template <bool M = inputs_2_merged_LUT_is_input_ordered, typename std::enable_if<M>::type* = nullptr>
+      inline int get_merged_idx_for_input(unsigned inputGVCFIdx, int inputIdx) const
+      { return get_lut_value(m_inputs_2_merged_lut, inputGVCFIdx, inputIdx); }
+      template <bool M = inputs_2_merged_LUT_is_input_ordered, typename std::enable_if<!M>::type* = nullptr>
+      inline int get_merged_idx_for_input(unsigned inputGVCFIdx, int inputIdx) const
+      { return get_lut_value(m_inputs_2_merged_lut, inputIdx, inputGVCFIdx); }
+
+      /**
+       * @brief reset/invalidate merged field index for field inputIdx of input VCF inputGVCFIdx
+       * @param inputGVCFIdx index of the input VCF file
+       * @param inputIdx index of the field in the input VCF file
+       */
+      inline void reset_merged_idx_for_input(unsigned inputGVCFIdx, int inputIdx)
+      {	set_merged_idx_for_input(inputGVCFIdx, inputIdx, gamgee::missing_values::int32); }
+      /**
+       * @brief reset/invalidate the input field index for input VCF inputGVCFIdx for merged field mergedIdx
+       * @param inputGVCFIdx index of the input VCF file
+       * @param mergedIdx index of the field in the merged VCF file
+       */
+      inline void reset_input_idx_for_merged(unsigned inputGVCFIdx, int mergedIdx)
+      {	set_input_idx_for_merged(inputGVCFIdx, gamgee::missing_values::int32, mergedIdx); }
+
+      protected:
+      //Only inherited classes should call constructor,destructor etc
+      MergedVCFLUTBase(); 
+      MergedVCFLUTBase(unsigned numInputGVCFs, unsigned numMergedFields);
+      ~MergedVCFLUTBase() = default;
+      /**
+       * @brief deallocates memory
+       */
+      void clear();
+
+      unsigned m_num_input_vcfs;
+      unsigned m_num_merged_fields;
+
+      /**
+       *  @brief resize LUT functions 
+       *  @note should be called relatively infrequently (more precisely, the reallocation code inside these resize functions should be called
+       *  infrequently
+       *  @param numInputGVCFs number of input VCFs
+       *  @param numMergedFields number of fields combined across all input VCFs
+       */
+      template <bool M = inputs_2_merged_LUT_is_input_ordered, typename std::enable_if<M>::type* = nullptr>
+      void resize_inputs_2_merged_lut_if_needed(unsigned numInputGVCFs, unsigned numMergedFields)
+      {	resize_and_reset_lut(m_inputs_2_merged_lut, numInputGVCFs, numMergedFields, m_num_input_vcfs, m_num_merged_fields); }
+
+      template <bool M = inputs_2_merged_LUT_is_input_ordered, typename std::enable_if<!M>::type* = nullptr>
+      void resize_inputs_2_merged_lut_if_needed(unsigned numInputGVCFs, unsigned numMergedFields)
+      {	resize_and_reset_lut(m_inputs_2_merged_lut, numMergedFields, numInputGVCFs, m_num_merged_fields, m_num_input_vcfs); }
+
+      template <bool M = merged_2_inputs_LUT_is_input_ordered, typename std::enable_if<M>::type* = nullptr>
+      void resize_merged_2_inputs_lut_if_needed(unsigned numInputGVCFs, unsigned numMergedFields)
+      {	resize_and_reset_lut(m_merged_2_inputs_lut, numInputGVCFs, numMergedFields, m_num_input_vcfs, m_num_merged_fields); }
+
+      template <bool M = merged_2_inputs_LUT_is_input_ordered, typename std::enable_if<!M>::type* = nullptr>
+      void resize_merged_2_inputs_lut_if_needed(unsigned numInputGVCFs, unsigned numMergedFields)
+      {	resize_and_reset_lut(m_merged_2_inputs_lut, numMergedFields, numInputGVCFs, m_num_merged_fields, m_num_input_vcfs); }
+
+      /*
+       * @brief wrapper around single LUT resize functions
+       */
+      void resize_luts_if_needed(unsigned numInputGVCFs, unsigned numMergedFields)
+      {
+	resize_merged_2_inputs_lut_if_needed(numInputGVCFs, numMergedFields);
+	resize_inputs_2_merged_lut_if_needed(numInputGVCFs, numMergedFields);
+      }
+      private:
+      //why not unordered_map? because I feel the need, the need for speed
+      std::vector<std::vector<int>> m_inputs_2_merged_lut;
+      std::vector<std::vector<int>> m_merged_2_inputs_lut;
+      /**
+       * @brief invalidate/reset all mappings in a vector
+       * @note sets all elements to missing
+       * @param vec the vector to reset
+       * @param from offset in the vector from which to start reset, 0 by default
+       */
+      void reset_vector(std::vector<int>& vec, unsigned from=0u);
+      /**
+       * @brief resize and reset a vector
+       * @note resize and reset is done only if new_size > vec.size()
+       */
+      void resize_and_reset_vector(std::vector<int>& vec, unsigned new_size);
+      /**
+       * @brief resize and reset a LUT
+       * @note resize and reset is done only if new_size > old_size
+       */
+      void resize_and_reset_lut(std::vector<std::vector<int>>& lut, unsigned new_lut_size, unsigned new_size, unsigned& numRowsVar, unsigned& numColsVar);
+
+      /**
+       * @brief get LUT value at a particular row,column
+       * @note should be called only from the public wrapper functions get_*() as the wrappers take care of memory layout
+       * @param lut LUT to access
+       * @param rowIdx row
+       * @param columnIdx column
+       * @return value at lut[row][column], could be invalid, check with is_missing()
+       */
+      inline int get_lut_value(const std::vector<std::vector<int>>& lut, int rowIdx, int columnIdx) const
+      {
+	assert(rowIdx >= 0);
+	assert(rowIdx < static_cast<int>(lut.size()));
+	assert(columnIdx >= 0);
+	assert(columnIdx < static_cast<int>(lut[rowIdx].size()));
+	return lut[rowIdx][columnIdx];
+      }
+
+      /**
+       * @brief set LUT value at a particular row,column
+       * @note should be called only from the public wrapper functions add_input_merged_idx_pair() or reset_*() as the wrappers take care of memory layout
+       * @param lut LUT to access
+       * @param rowIdx row
+       * @param columnIdx column
+       * @param value value to write at lut[row][column] 
+       */
+      inline void set_lut_value(std::vector<std::vector<int>>& lut, int rowIdx, int columnIdx, int value)
+      {
+	assert(rowIdx >= 0);
+	assert(rowIdx < static_cast<int>(lut.size()));
+	assert(columnIdx >= 0);
+	assert(columnIdx < static_cast<int>(lut[rowIdx].size()));
+	lut[rowIdx][columnIdx] = value;
+      }
+
+      /**
+       * @brief set merged field idx value (mergedIdx) corresponding to field idx inputIdx for input VCF inputGVCFIdx
+       * @note should be called only from the public wrapper functions add_input_merged_idx_pair() or reset_*() as the wrappers take care of memory layout
+       * @param inputGVCFIdx index of the input VCF file
+       * @param inputIdx index of the field in the input VCF file
+       * @param mergedIdx index of the field in the merged VCF file
+       */
+      template <bool M = inputs_2_merged_LUT_is_input_ordered, typename std::enable_if<M>::type* = nullptr>
+      inline void set_merged_idx_for_input(unsigned inputGVCFIdx, int inputIdx, int mergedIdx)
+      { set_lut_value(m_inputs_2_merged_lut, inputGVCFIdx, inputIdx, mergedIdx); } 
+
+      template <bool M = inputs_2_merged_LUT_is_input_ordered, typename std::enable_if<!M>::type* = nullptr>
+      inline void set_merged_idx_for_input(unsigned inputGVCFIdx, int inputIdx, int mergedIdx)
+      { set_lut_value(m_inputs_2_merged_lut, inputIdx, inputGVCFIdx, mergedIdx); } 
+
+      /**
+       * @brief set input field idx value (inputIdx) for input VCF inputGVCFIdx corresponding to field idx mergedIdx in the merged VCF
+       * @note should be called only from the public wrapper functions add_input_merged_idx_pair() or reset_*() as the wrappers take care of memory layout
+       * @param inputGVCFIdx index of the input VCF file
+       * @param inputIdx index of the field in the input VCF file
+       * @param mergedIdx index of the field in the merged VCF file
+       */
+      template <bool M = merged_2_inputs_LUT_is_input_ordered, typename std::enable_if<M>::type* = nullptr>
+      inline void set_input_idx_for_merged(unsigned inputGVCFIdx, int inputIdx, int mergedIdx)
+      { set_lut_value(m_merged_2_inputs_lut, inputGVCFIdx, mergedIdx, inputIdx); }
+
+      template <bool M = merged_2_inputs_LUT_is_input_ordered, typename std::enable_if<!M>::type* = nullptr>
+      inline void set_input_idx_for_merged(unsigned inputGVCFIdx, int inputIdx, int mergedIdx)
+      { set_lut_value(m_merged_2_inputs_lut, mergedIdx, inputGVCFIdx, inputIdx); }
+
+    };
+
+    /**
+     * @brief LUT class for storing mappings between allele vectors in the merged file and input VCF files
+     * Since the #alleles per site is expected to be small, this class sets the number of fields to 10. This makes any subsequent re-allocations
+     * unlikely. The function resize_luts_if_needed() will almost always return immediately after failing the if condition
+     */
+    template<bool inputs_2_merged_LUT_is_input_ordered, bool merged_2_inputs_LUT_is_input_ordered>
+    class MergedVCFAllelesIdxLUT
+    : public MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>
+    {
+      private:
+	static const auto m_DEFAULT_INIT_NUM_ALLELES=10u;
+      public:
+	MergedVCFAllelesIdxLUT(unsigned numInputGVCFs)
+	  : MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>(numInputGVCFs,
+	      m_DEFAULT_INIT_NUM_ALLELES)
+	  { m_max_num_alleles = m_DEFAULT_INIT_NUM_ALLELES; }
+	inline void resize_luts_if_needed(unsigned numMergedAlleles)
+	{
+	  if(numMergedAlleles > m_max_num_alleles)
+	  {
+	    MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>::resize_luts_if_needed(
+		MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>::m_num_input_vcfs, numMergedAlleles); 
+	    m_max_num_alleles = numMergedAlleles;
+	  }
+	}
+      private:
+	unsigned m_max_num_alleles;
+    };
+
+    /*NOTE: Needs explicit instantiation in .cpp file to use this type alias*/
+    using CombineAllelesLUT = MergedVCFAllelesIdxLUT<true,true>;
+  }
+}
+
+#endif

--- a/gamgee/variant_header.h
+++ b/gamgee/variant_header.h
@@ -9,7 +9,9 @@
 #include <vector>
 
 namespace gamgee {
-  
+
+template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+class VariantHeaderMerger;  //forward declaration to declare friendship in VariantHeader
 /**
  * @brief Utility class to hold a variant header
  *
@@ -150,6 +152,26 @@ class VariantHeader {
     return index >= 0 ? index : missing_values::int32;
   }
 
+  std::string get_field_name(const int32_t field_idx) const {
+    if(field_idx >= 0 && field_idx < m_header->n[BCF_DT_ID])
+    {
+      auto name_ptr = bcf_hdr_int2id(m_header.get(), BCF_DT_ID, field_idx);
+      if(name_ptr)
+	return name_ptr;
+    }
+    return "";
+  }
+
+  std::string get_sample_name(const int32_t sample_idx) const {
+    if(sample_idx >= 0 && sample_idx < m_header->n[BCF_DT_SAMPLE])
+    {
+      auto name_ptr= bcf_hdr_int2id(m_header.get(), BCF_DT_SAMPLE, sample_idx);
+      if(name_ptr)
+	return name_ptr;
+    }
+    return "";
+  }
+
  private:
   std::shared_ptr<bcf_hdr_t> m_header;
 
@@ -159,6 +181,8 @@ class VariantHeader {
   friend class VariantBuilder;       ///< builder needs access to the internals in order to build efficiently
   friend class VariantBuilderSharedRegion;
   friend class VariantBuilderIndividualRegion;
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  friend class VariantHeaderMerger;  //to access m_header
 };
 
 }

--- a/gamgee/variant_header_merger.cpp
+++ b/gamgee/variant_header_merger.cpp
@@ -1,0 +1,139 @@
+#include "variant_header_merger.h"
+#include "utils/variant_utils.h"
+#include "utils/hts_memory.h"
+
+using namespace std;
+
+namespace gamgee
+{
+  //VariantHeaderMerger functions
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  void 
+  VariantHeaderMerger<fields_forward_LUT_ordering, fields_reverse_LUT_ordering, samples_forward_LUT_ordering, samples_reverse_LUT_ordering>::
+  add_header_fields_mapping(bcf_hdr_t* curr_header, unsigned input_vcf_idx)
+  {
+    assert(m_merged_vcf_header_ptr);
+    for(auto j=0;j<curr_header->n[BCF_DT_ID];++j)
+    {
+      auto curr_id = &(curr_header->id[BCF_DT_ID][j]);
+      for(auto bcf_hl_type : { BCF_HL_FLT, BCF_HL_INFO, BCF_HL_FMT })
+      {
+	//id has been deleted - ignore
+	if(!bcf_hdr_idinfo_exists(curr_header, bcf_hl_type, j))
+	  continue;
+	bcf_hrec_t* hrec = bcf_hdr_id2hrec(curr_header, BCF_DT_ID, bcf_hl_type, j);
+	if(hrec) //not deleted
+	{
+	  const char* key = curr_id->key;
+	  auto merged_idx = bcf_hdr_id2int(m_merged_vcf_header_ptr.get(), BCF_DT_ID, key);
+	  assert(merged_idx >= 0 && merged_idx < m_merged_vcf_header_ptr->n[BCF_DT_ID]);
+	  assert(bcf_hdr_idinfo_exists(m_merged_vcf_header_ptr, bcf_hl_type, merged_idx));
+	  m_header_fields_LUT.add_input_merged_idx_pair(input_vcf_idx, j, merged_idx);
+	}
+      }
+    }
+  }
+
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  void 
+  VariantHeaderMerger<fields_forward_LUT_ordering, fields_reverse_LUT_ordering, samples_forward_LUT_ordering, samples_reverse_LUT_ordering>::
+  add_samples_mapping(bcf_hdr_t* curr_header, unsigned input_vcf_idx)
+  {
+    for(auto j=0;j<bcf_hdr_nsamples(curr_header);++j)
+    {
+      if(curr_header->samples[j] && bcf_hdr_id2int(curr_header, BCF_DT_SAMPLE, curr_header->samples[j]) >= 0)
+      {
+	if(m_sample2idx_merged.find(curr_header->samples[j]) == m_sample2idx_merged.end())
+	{
+	  auto curr_size = m_sample2idx_merged.size();
+	  m_sample2idx_merged[curr_header->samples[j]] = curr_size;
+	}
+	m_samples_LUT.add_input_merged_idx_pair(input_vcf_idx, j, m_sample2idx_merged[curr_header->samples[j]]);
+      }
+      else
+	m_samples_LUT.reset_merged_idx_for_input(input_vcf_idx, j);
+    }
+  }
+
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  void 
+  VariantHeaderMerger<fields_forward_LUT_ordering, fields_reverse_LUT_ordering, samples_forward_LUT_ordering, samples_reverse_LUT_ordering>::
+  add_header(const shared_ptr<bcf_hdr_t>& header_ptr)
+  {
+    if(m_merged_vcf_header_ptr)
+      merge_variant_headers(m_merged_vcf_header_ptr, header_ptr);
+    else
+      m_merged_vcf_header_ptr = utils::make_shared_variant_header(utils::variant_header_deep_copy(header_ptr.get()));
+    auto header_raw_ptr = header_ptr.get();
+    assert(m_merged_vcf_header_ptr);
+    m_input_vcf_headers.push_back(header_ptr);
+    resize_luts_if_needed();
+
+    unsigned input_vcf_idx = m_input_vcf_headers.size()-1;
+    add_header_fields_mapping(header_raw_ptr, input_vcf_idx);
+    add_samples_mapping(header_raw_ptr, input_vcf_idx);
+  }
+
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  void 
+  VariantHeaderMerger<fields_forward_LUT_ordering, fields_reverse_LUT_ordering, samples_forward_LUT_ordering, samples_reverse_LUT_ordering>::
+  add_header(const VariantHeader& header)
+  {
+    add_header(header.m_header);
+  }
+
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  void 
+  VariantHeaderMerger<fields_forward_LUT_ordering, fields_reverse_LUT_ordering, samples_forward_LUT_ordering, samples_reverse_LUT_ordering>::
+  add_headers(const vector<shared_ptr<bcf_hdr_t>>& headers)
+  {
+    for(const auto& header : headers)
+      add_header(header);
+  }
+
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  void 
+  VariantHeaderMerger<fields_forward_LUT_ordering, fields_reverse_LUT_ordering, samples_forward_LUT_ordering, samples_reverse_LUT_ordering>::
+  add_headers(const vector<VariantHeader>& headers)
+  {
+    for(const auto& header : headers)
+      add_header(header);
+  }
+
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  void 
+  VariantHeaderMerger<fields_forward_LUT_ordering, fields_reverse_LUT_ordering, samples_forward_LUT_ordering, samples_reverse_LUT_ordering>::
+  resize_luts_if_needed()
+  {
+    if(m_num_merged_fields_allocated < static_cast<unsigned>(m_merged_vcf_header_ptr->n[BCF_DT_ID]))
+      m_num_merged_fields_allocated = m_merged_vcf_header_ptr->n[BCF_DT_ID] + 20;	//why 20, no particular reason
+    if(m_input_vcf_headers.size() < m_num_input_vcfs_allocated)
+      m_num_input_vcfs_allocated = 2*m_input_vcf_headers.size();
+    if(m_num_merged_samples_allocated < static_cast<unsigned>(bcf_hdr_nsamples(m_merged_vcf_header_ptr)))
+      m_num_merged_samples_allocated = 2*bcf_hdr_nsamples(m_merged_vcf_header_ptr);
+    m_header_fields_LUT.resize_luts_if_needed(m_num_input_vcfs_allocated, m_num_merged_fields_allocated);
+    m_samples_LUT.resize_luts_if_needed(m_num_input_vcfs_allocated, m_num_merged_samples_allocated);
+    m_merged_field_idx_enum_lut.resize_luts_if_needed(1u, m_num_merged_fields_allocated);
+  }
+
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  void 
+  VariantHeaderMerger<fields_forward_LUT_ordering, fields_reverse_LUT_ordering, samples_forward_LUT_ordering, samples_reverse_LUT_ordering>::
+  store_merged_field_idx_for_enum(const string& field_name, unsigned field_enum)
+  {
+    if(field_enum >= m_num_enums_allocated)
+    {
+      m_num_enums_allocated = 2u*field_enum + 1u;
+      m_merged_field_idx_enum_lut.resize_luts_if_needed(1u, m_num_enums_allocated);
+    }
+    auto val =  bcf_hdr_id2int(m_merged_vcf_header_ptr.get(), BCF_DT_ID, field_name.c_str());
+    if(val == -1)
+      m_merged_field_idx_enum_lut.reset_merged_idx_for_input(0u, field_enum);
+    else
+      m_merged_field_idx_enum_lut.add_input_merged_idx_pair(0u, field_enum, val);
+  }
+
+  //explicit initialization to avoid link errors
+  template class VariantHeaderMerger<true, true, true, true>;
+  template class VariantHeaderMerger<false, false, false, false>;
+}

--- a/gamgee/variant_header_merger.h
+++ b/gamgee/variant_header_merger.h
@@ -1,0 +1,318 @@
+#ifndef __gamgee_variant_header_merger__
+#define __gamgee_variant_header_merger__
+
+#include <boost/shared_ptr.hpp>
+#include <string>
+#include <unordered_map>
+#include "utils/merged_vcf_lut.h"
+
+namespace gamgee
+{
+  /*
+   * VariantHeaderMerger class
+   * @brief Class for merging VCF headers and maintain field and sample mappings
+   * Class which:
+   * (a) Merges multiple input VCF headers to obtain a merged VCF header
+   * (b) Creates and updates mappings between input VCFs and merged VCF header fields and samples.
+   * 
+   * Provides functions to add new VCF headers for merging
+   * Example usage:
+   * shared_ptr<bcf_hdr_t> vcf_hdr;
+   * vector<shared_ptr<bcf_hdr_t>> hdr_vec1;
+   * vector<shared_ptr<bcf_hdr_t>> hdr_vec2;
+   *
+   * Start with empty object, add headers later
+   * VariantHeaderMerger X;
+   * X.add_header(vcf_hdr);
+   * X.add_headers(hdr_vec1);
+   * const shared_ptr<bcf_hdr_t>& merged_hdr = X.get_merged_header();
+   *
+   * Start with 1, add more later
+   * VariantHeaderMerger Y { vcf_hdr };
+   * Y.add_headers(hdr_vec1);
+   *
+   * Start with many, add more later
+   * VariantHeaderMerger Z { hdr_vec1 };
+   * Z.add_headers(hdr_vec2);
+   *
+   * The class contains two LUTs - m_header_fields_LUT and m_samples_LUT of type MergedVCFLUTBase<> for storing mapping for
+   * header fields (FMT, FLT, INFO) and samples respectively. The class is templated to select the 'best' memory layout.
+   * 
+   * Each of the two MergedVCFLUTBase<> objects (m_header_fields_LUT, m_samples_LUT) contains two matrices (vector<vector<int>>):
+   * m_inputs_2_merged_lut and m_merged_2_inputs_lut. The first stores the mapping from input VCF fields to the merged VCF fields while
+   * the second stores the mapping in the opposite direction.
+   * You can layout each matrix in one of the 2 following ways:
+   * (a) matrix[i][j]  corresponds to input VCF i and field j 
+   * (b) matrix[i][j]  corresponds to field i and input VCF j
+   * Option (a) is optimal where you are looking at all the fields of a VCF in quick succession,
+   * while (b) is optimal when you are looking at all VCFs for a particular field.
+   * The 2 boolean template parameters for MergedVCFLUTBase<inputs_2_merged_LUT_is_input_ordered, merged_2_inputs_LUT_is_input_ordered>
+   * control the layout of the two matrices. If the parameter inputs_2_merged_LUT_is_input_ordered is true, then layout (a) is selected for
+   * m_inputs_2_merged_lut, else layout (b)
+   *
+   * VariantHeaderMerger has 4 boolean parameters - two for the m_header_fields_LUT (fields_*_LUT_ordering) and two for the
+   * m_samples_LUT (samples_*_LUT_ordering)
+   * fields_forward_LUT_ordering: controls the layout of the input VCF fields to merged VCF fields matrix in m_header_fields_LUT
+   * fields_reverse_LUT_ordering: controls the layout of the merged VCF fields to input VCF fields matrix in m_header_fields_LUT
+   * samples_forward_LUT_ordering: controls the layout of the input VCF fields to merged VCF samples matrix in m_samples_LUT
+   * samples_reverse_LUT_ordering: controls the layout of the merged VCF samples to input VCF samples matrix in m_samples_LUT
+   *
+   * We create type aliases InputOrderedVariantHeaderMerger and FieldOrderedVariantHeaderMerger for specialized template
+   * instantiations of VariantHeaderMerger.
+   * (a) InputOrderedVariantHeaderMerger - fast traversal of all field lookups for a single input VCF
+   * (b) FieldOrderedVariantHeaderMerger - fast traversal of all input VCFs for a single field lookup
+   *
+   * Example usage:
+   * vector<VariantHeader> hdr_vec;
+   * VariantHeaderMerger Z { hdr_vec };
+   * auto input_vcf_idx = 0u;
+   * auto input_PL_idx = hdr_vec[input_vcf_idx].field_index("PL", BCF_HL_FMT);
+   * auto merged_PL_idx = Z.get_merged_header_idx_for_input(input_vcf_idx, input_PL_idx);
+   * auto refind_input_PL_idx = Z.get_input_header_idx_for_merged(input_vcf_idx, merged_PL_idx);
+   * assert(refind_input_PL_idx == input_PL_idx);
+   */
+
+  template<bool fields_forward_LUT_ordering, bool fields_reverse_LUT_ordering, bool samples_forward_LUT_ordering, bool samples_reverse_LUT_ordering>
+  class VariantHeaderMerger
+  {
+    private:
+      static const auto m_DEFAULT_INIT_NUM_INPUT_VCFS  = 10u;
+      static const auto m_DEFAULT_INIT_NUM_FIELDS = 30u;
+      static const auto m_DEFAULT_INIT_NUM_SAMPLES = 10u;
+    public:
+      /**
+       * @brief empty constructor, initialize 'large' LUTs
+       */
+      VariantHeaderMerger()
+	: m_header_fields_LUT{ m_DEFAULT_INIT_NUM_INPUT_VCFS,  m_DEFAULT_INIT_NUM_FIELDS },
+	m_samples_LUT { m_DEFAULT_INIT_NUM_INPUT_VCFS, m_DEFAULT_INIT_NUM_SAMPLES },
+	m_merged_field_idx_enum_lut { 1u, m_DEFAULT_INIT_NUM_FIELDS }
+      {
+	reset();
+	m_num_input_vcfs_allocated = m_DEFAULT_INIT_NUM_INPUT_VCFS;
+	m_num_merged_fields_allocated = m_DEFAULT_INIT_NUM_FIELDS;
+	m_num_merged_samples_allocated = m_DEFAULT_INIT_NUM_SAMPLES;
+	m_num_enums_allocated = m_DEFAULT_INIT_NUM_FIELDS;
+      }
+      /**
+       * @brief Constructor with a single input VCF header as input 
+       * @param input_vcf_header header of input VCF
+       */
+      VariantHeaderMerger(const std::shared_ptr<bcf_hdr_t>& input_vcf_header)
+	: VariantHeaderMerger() 
+      {
+	add_header(input_vcf_header);
+      }
+      /**
+       * @brief Constructor with a single input VCF header as input 
+       * @param input_vcf_header header of input VCF
+       */
+      VariantHeaderMerger(const VariantHeader& input_vcf_header)
+	: VariantHeaderMerger(input_vcf_header.m_header) 
+      { }
+      /**
+       * @brief Constructor with a vector of input VCF headers to be merged
+       * @param input_vcf_headers vector of headers of input VCFs which are being merged
+       */
+      VariantHeaderMerger(const std::vector<std::shared_ptr<bcf_hdr_t>>& input_vcf_headers)
+	: m_header_fields_LUT{ static_cast<unsigned>(input_vcf_headers.size()),  m_DEFAULT_INIT_NUM_FIELDS },
+	m_samples_LUT { static_cast<unsigned>(input_vcf_headers.size()), m_DEFAULT_INIT_NUM_SAMPLES },
+	m_merged_field_idx_enum_lut { 1u, m_DEFAULT_INIT_NUM_FIELDS }
+      {
+	reset();
+	m_num_input_vcfs_allocated = input_vcf_headers.size();
+	m_num_merged_fields_allocated = m_DEFAULT_INIT_NUM_FIELDS;
+	m_num_merged_samples_allocated = m_DEFAULT_INIT_NUM_SAMPLES;
+	m_num_enums_allocated = m_DEFAULT_INIT_NUM_FIELDS;
+	add_headers(input_vcf_headers);
+      }
+      /**
+       * @brief Constructor with a vector of input VCF headers to be merged
+       * @param input_vcf_headers vector of headers of input VCFs which are being merged
+       */
+      VariantHeaderMerger(const std::vector<VariantHeader>& input_vcf_headers)
+	: m_header_fields_LUT{ static_cast<unsigned>(input_vcf_headers.size()),  m_DEFAULT_INIT_NUM_FIELDS },
+	m_samples_LUT { static_cast<unsigned>(input_vcf_headers.size()), m_DEFAULT_INIT_NUM_SAMPLES },
+	m_merged_field_idx_enum_lut { 1u, m_DEFAULT_INIT_NUM_FIELDS }
+      {
+	reset();
+	m_num_input_vcfs_allocated = input_vcf_headers.size();
+	m_num_merged_fields_allocated = m_DEFAULT_INIT_NUM_FIELDS;
+	m_num_merged_samples_allocated = m_DEFAULT_INIT_NUM_SAMPLES;
+	m_num_enums_allocated = m_DEFAULT_INIT_NUM_FIELDS;
+	add_headers(input_vcf_headers);
+      }
+      /*
+       * @brief No anticipated use of a deep copy for VariantHeaderMerger
+       */
+      VariantHeaderMerger(const VariantHeaderMerger&) = delete;
+      VariantHeaderMerger& operator=(const VariantHeaderMerger&) = delete;
+      /*
+       * @brief default move constructor for VariantHeaderMerger
+       */
+      VariantHeaderMerger(VariantHeaderMerger&&) = default;
+      VariantHeaderMerger& operator=(VariantHeaderMerger&&) = default;
+
+      ~VariantHeaderMerger() = default;
+      /**
+       * @brief: resets all mappings, but does not de-allocate LUT memory
+       */
+      void reset()
+      {
+	m_input_vcf_headers.clear();
+	m_sample2idx_merged.clear();
+	m_merged_vcf_header_ptr = nullptr;
+	m_num_merged_fields_allocated = 0u;
+	m_num_merged_samples_allocated = 0u;
+	m_num_input_vcfs_allocated = 0u;
+	m_num_enums_allocated = 0u;
+	m_header_fields_LUT.reset_luts();
+	m_samples_LUT.reset_luts();
+	m_merged_field_idx_enum_lut.reset_luts();
+      }
+      /**
+       * @brief: resets all mappings, de-allocates LUT memory
+       */
+      void clear()
+      {
+	reset();
+	m_header_fields_LUT.clear();
+	m_samples_LUT.clear();
+	m_merged_field_idx_enum_lut.clear();
+      }
+      /**
+       * @brief add a new header into the merged header and update LUTs
+       * @param hdr new input header to add
+       */
+      void add_header(const std::shared_ptr<bcf_hdr_t>& hdr);
+      /**
+       * @brief add a new header into the merged header and update LUTs
+       * @param hdr new input header to add
+       */
+      void add_header(const VariantHeader& hdr);
+      /**
+       * @brief add a vector of new VCF headers into the merged header and update LUTs
+       * @param headers vector of new input VCF headers to add
+       */
+      void add_headers(const std::vector<std::shared_ptr<bcf_hdr_t>>& headers);
+      /**
+       * @brief add a vector of new VCF headers into the merged header and update LUTs
+       * @param headers vector of new input VCF headers to add
+       */
+      void add_headers(const std::vector<VariantHeader>& headers); 
+      /**
+       * @brief Get merged VCF header shared_ptr
+       * @return return the merged VCF header shared_ptr
+       */
+      const std::shared_ptr<bcf_hdr_t>& get_raw_merged_header() const { return m_merged_vcf_header_ptr; }
+      /**
+       * @brief Get merged VCF header
+       * @return return the merged VCF header
+       */
+      const VariantHeader get_merged_header() const { return VariantHeader{ m_merged_vcf_header_ptr }; }
+      /*LUT functions*/
+      /**
+       * @brief Get sample idx for the merged VCF corresponding to sample idx inputSampleIdx in the input VCF of index inputGVCFIdx
+       * @param inputGVCFIdx index of the input VCF file
+       * @param inputSampleIdx index of the sample in the input VCF file
+       * @return index of the sample in the merged VCF file
+       */
+      inline int get_merged_sample_idx_for_input(unsigned inputGVCFIdx, int inputSampleIdx) const
+      { return m_samples_LUT.get_merged_idx_for_input(inputGVCFIdx, inputSampleIdx); }
+      /**
+       * @brief Get header field (FLT/FMT/INFO) idx for the merged VCF corresponding to field idx inputIdx in the input VCF of index inputGVCFIdx
+       * @param inputGVCFIdx index of the input VCF file
+       * @param inputIdx index of the field in the input VCF file
+       * @return index of the field in the merged VCF file
+       */
+      inline int get_merged_header_idx_for_input(unsigned inputGVCFIdx, int inputIdx) const
+      { return m_header_fields_LUT.get_merged_idx_for_input(inputGVCFIdx, inputIdx); }
+      /**
+       * @brief Get sample idx for the input VCF inputGVCFIdx corresponding to sample mergedSampleIdx in the merged VCF 
+       * @param inputGVCFIdx index of the input VCF file
+       * @param mergedSampleIdx index of the sample in the merged VCF file
+       * @return index of the sample in the input VCF file inputGVCFIdx
+       */
+      inline int get_input_sample_idx_for_merged(unsigned inputGVCFIdx, int mergedSampleIdx) const
+      { return m_samples_LUT.get_input_idx_for_merged(inputGVCFIdx, mergedSampleIdx); }
+      /**
+       * @brief Get header field (FLT/FMT/INFO) idx for the input VCF inputGVCFIdx corresponding to field mergedIdx in the merged VCF 
+       * @param inputGVCFIdx index of the input VCF file
+       * @param mergedIdx index of the field in the merged VCF file
+       * @return index of the field in the input VCF file inputGVCFIdx
+       */
+      inline int get_input_header_idx_for_merged(unsigned inputGVCFIdx, int mergedIdx) const
+      { return m_header_fields_LUT.get_input_idx_for_merged(inputGVCFIdx, mergedIdx); }
+
+      /**
+       * @brief utility function for storing index of frequently used fields in the merged VCF
+       * Sometimes the user/developer may know beforehand that certain fields are needed/accesssed (for example "PL")
+       * for every variant in a merged VCF
+       * Instead of doing a string search everytime, the user may wish to define an enum corresponding to the relevant fields
+       * and store the index of the relevant fields in the merged VCF after the merged header is built. Subsequent accesses to
+       * the fields need not use any string searches, instead directly using the idx in the LUT
+       * Example, the user could define an enum { PL_FIELD=0, AD_FIELD, AF_FIELD } and call the function
+       * store_merged_field_idx_for_enum("PL", PL_FIELD);
+       * store_merged_field_idx_for_enum("AD", AD_FIELD); ...
+       *
+       * While processing variants, the user could directly use the merged field idx using the function
+       * auto merged_PL_idx = get_merged_field_idx_for_enum(PL_FIELD);
+       * This completely avoids string searches during variant processing
+       *
+       * The reverse function (get_enum_for_merged_field_idx) is also useful:
+       * for(i=0;i<bcf1_t->n_info;++i)
+       * {
+       *   switch(VariantHeaderMerger.get_enum_for_merged_field_idx(bcf1_t->d.info[i].key))
+       *   {
+       *      case PL_FIELD:
+       *        do_something_with_PL();
+       *        break;
+       *      ....
+       *   }
+       * }
+       */
+      void store_merged_field_idx_for_enum(const std::string& field, unsigned field_enum_idx);
+      inline int get_merged_field_idx_for_enum(unsigned field_enum_idx) const
+      {
+	return m_merged_field_idx_enum_lut.get_merged_idx_for_input(0u, field_enum_idx);
+      }
+      inline int get_enum_for_merged_field_idx(int merged_field_idx) const
+      {
+	return m_merged_field_idx_enum_lut.get_input_idx_for_merged(0u, merged_field_idx);
+      }
+    private:
+      /**
+       * @brief function to resize LUTs if needed
+       */
+      void resize_luts_if_needed();
+      //LUT for VCF header fields (FMT/FLT/INFO)
+      utils::MergedVCFLUTBase<fields_forward_LUT_ordering, fields_reverse_LUT_ordering> m_header_fields_LUT;
+      //LUT for samples
+      utils::MergedVCFLUTBase<samples_forward_LUT_ordering, samples_reverse_LUT_ordering> m_samples_LUT;
+      //Header fields mapping
+      void add_header_fields_mapping(bcf_hdr_t* curr_header, unsigned input_vcf_idx);
+      //Samples mapping
+      void add_samples_mapping(bcf_hdr_t* curr_header, unsigned input_vcf_idx);
+      //Global sample names to idx mapping
+      std::unordered_map<std::string,int> m_sample2idx_merged;
+      //Input VCF headers
+      std::vector<std::shared_ptr<bcf_hdr_t>> m_input_vcf_headers;
+      //Merged header
+      std::shared_ptr<bcf_hdr_t> m_merged_vcf_header_ptr;
+      //sizes of the LUTs - to determine when to reallocate
+      unsigned m_num_merged_fields_allocated;
+      unsigned m_num_merged_samples_allocated;
+      unsigned m_num_input_vcfs_allocated;
+      unsigned m_num_enums_allocated;
+      //LUT to store merged field idxs to user-defined enum mappings
+      //The two matrices in this LUT are single row matrices - the matrix m_inputs_2_merged_lut will
+      //store the mapping from the user defined enum to the merged VCF header field idx, while the
+      //matrix m_merged_2_inputs will store the enum corresponding to the merged field
+      utils::MergedVCFLUTBase<true, true> m_merged_field_idx_enum_lut;
+  };
+  /*NOTE: Needs explicit instantiation in .cpp file to use this type alias*/
+  using InputOrderedVariantHeaderMerger = VariantHeaderMerger<true,true,true,true>;
+  using FieldOrderedVariantHeaderMerger = VariantHeaderMerger<false,false,false,false>;
+}
+
+#endif

--- a/test/reference_block_splitting_variant_reader_test.cpp
+++ b/test/reference_block_splitting_variant_reader_test.cpp
@@ -34,6 +34,229 @@ BOOST_AUTO_TEST_CASE( split_reference_blocks )
   BOOST_CHECK_EQUAL(position_counter, truth_contigs.size());
 }
 
+template<bool v1, bool v2>
+void test_lut_base()
+{
+  utils::MergedVCFLUTBase<v1, v2> lut {};
+  lut.resize_luts_if_needed(10u, 14u);
+  //Check size
+  BOOST_CHECK_EQUAL(lut.m_num_input_vcfs, 10u);
+  BOOST_CHECK_EQUAL(lut.m_num_merged_fields, 14u);
+  //Everything should be invalid/missing
+  for(auto i=0u;i<lut.m_num_input_vcfs;++i)
+    for(auto j=0u;j<lut.m_num_merged_fields;++j)
+    {
+      BOOST_CHECK(gamgee::missing(lut.get_input_idx_for_merged(i,j)));
+      BOOST_CHECK(gamgee::missing(lut.get_merged_idx_for_input(i,j)));
+    }
+  lut.add_input_merged_idx_pair(5u, 4, 7);
+  //Everything should be invalid/missing, except for the pair added above
+  for(auto i=0u;i<lut.m_num_input_vcfs;++i)
+    for(auto j=0u;j<lut.m_num_merged_fields;++j)
+    {
+      if(i != 5u && j != 7u)
+      {
+	BOOST_CHECK(gamgee::missing(lut.get_input_idx_for_merged(i,j)));
+      }
+      if(i != 5u && j != 4u)
+      {
+	BOOST_CHECK(gamgee::missing(lut.get_merged_idx_for_input(i,j)));
+      }
+    }
+  BOOST_CHECK_EQUAL(lut.get_input_idx_for_merged(5u,7), 4);
+  BOOST_CHECK_EQUAL(lut.get_merged_idx_for_input(5u,4), 7);
+  //resize
+  lut.resize_luts_if_needed(12u, 17u);
+  //Check size
+  BOOST_CHECK_EQUAL(lut.m_num_input_vcfs, 12u);
+  BOOST_CHECK_EQUAL(lut.m_num_merged_fields, 17u);
+  //Everything should be invalid/missing, except for the pair added above
+  for(auto i=0u;i<lut.m_num_input_vcfs;++i)
+    for(auto j=0u;j<lut.m_num_merged_fields;++j)
+    {
+      if(i != 5u && j != 7u)
+      {
+	BOOST_CHECK(gamgee::missing(lut.get_input_idx_for_merged(i,j)));
+      }
+      if(i != 5u && j != 4u)
+      {
+	BOOST_CHECK(gamgee::missing(lut.get_merged_idx_for_input(i,j)));
+      }
+    }
+  BOOST_CHECK_EQUAL(lut.get_input_idx_for_merged(5u,7), 4);
+  BOOST_CHECK_EQUAL(lut.get_merged_idx_for_input(5u,4), 7);
+  //reset 1 direction of the LUT
+  lut.reset_merged_idx_for_input(5u, 4);
+  BOOST_CHECK(gamgee::missing(lut.get_merged_idx_for_input(5u, 4)));
+  BOOST_CHECK_EQUAL(lut.get_input_idx_for_merged(5u,7), 4);
+  //reset other direction of the LUT
+  lut.reset_input_idx_for_merged(5u, 7);
+  BOOST_CHECK(gamgee::missing(lut.get_merged_idx_for_input(5u, 4)));
+  BOOST_CHECK(gamgee::missing(lut.get_input_idx_for_merged(5u,7)));
+}
+
+BOOST_AUTO_TEST_CASE( merged_vcf_lut_test )
+{
+  test_lut_base<true, true>();
+  test_lut_base<true, false>();
+  test_lut_base<false, true>();
+  test_lut_base<false, false>();
+  utils::CombineAllelesLUT Z{5u};
+  Z.add_input_merged_idx_pair(3u, 4, 8);
+  BOOST_CHECK_EQUAL(Z.get_input_idx_for_merged(3u, 8), 4);
+  BOOST_CHECK_EQUAL(Z.get_merged_idx_for_input(3u, 4), 8);
+  BOOST_CHECK(gamgee::missing(Z.get_merged_idx_for_input(2u, 7)));
+  Z.resize_luts_if_needed(15u);
+  BOOST_CHECK_EQUAL(Z.get_input_idx_for_merged(3u, 8), 4);
+  BOOST_CHECK_EQUAL(Z.get_merged_idx_for_input(3u, 4), 8);
+  BOOST_CHECK(gamgee::missing(Z.get_merged_idx_for_input(2u, 7)));
+}
+
+enum VariantHeaderMergerTestPathEnum
+{
+  INPUT_FIELD_MISSING=0,
+  INPUT_FIELD_VALID,
+  INPUT_SAMPLE_MISSING,
+  INPUT_SAMPLE_VALID,
+  PL_ENUM_VALID,
+  AD_ENUM_VALID,
+  AF_ENUM_VALID,
+  INVALID_ENUM_INVALID,
+  TOTAL_NUM_VARIANT_HEADER_MERGER_TEST_PATHS
+};
+
+enum VariantHeaderMergerFieldsEnum
+{
+  PL_FIELD=0,
+  AD_FIELD,
+};
+
+template<class VariantHeaderMergerTy>
+void test_variant_header_merger(VariantHeaderMergerTy& merger, const VariantHeader& combined_header, const shared_ptr<bcf_hdr_t>& header,
+    unsigned input_vcf_idx, vector<unsigned>& test_path_counters)
+{
+  //merged field-enum mappings
+  merger.store_merged_field_idx_for_enum("PL", PL_FIELD);
+  merger.store_merged_field_idx_for_enum("AD", AD_FIELD);
+  //test large enum value
+  merger.store_merged_field_idx_for_enum("AF", 100u);
+  //Every field/sample in the merged header is either in the input header or isn't
+  //Information in both the LUT and the header should match
+  for(auto merged_field_idx=0u;merged_field_idx<1000u;++merged_field_idx)	//large number
+  {
+    for(auto field_type : {BCF_HL_FLT, BCF_HL_INFO, BCF_HL_FMT})
+      if(combined_header.has_field(merged_field_idx, field_type))
+      {
+	auto input_field_idx = merger.get_input_header_idx_for_merged(input_vcf_idx, static_cast<int>(merged_field_idx));
+	auto header_field_idx = bcf_hdr_id2int(header.get(), BCF_DT_ID, combined_header.get_field_name(merged_field_idx).c_str());
+	if(gamgee::missing(input_field_idx))
+	{
+	  BOOST_CHECK_EQUAL(header_field_idx, -1);
+	  ++test_path_counters[INPUT_FIELD_MISSING];
+	}
+	else
+	{
+	  BOOST_CHECK_EQUAL(header_field_idx, input_field_idx);
+	  bool at_least_one_valid_type = false;
+	  for(auto input_field_type : {BCF_HL_FLT, BCF_HL_INFO, BCF_HL_FMT})
+	    at_least_one_valid_type = (at_least_one_valid_type ||  bcf_hdr_idinfo_exists(header.get(), input_field_type, input_field_idx));
+	  BOOST_CHECK(at_least_one_valid_type);
+	  BOOST_CHECK(bcf_hdr_int2id(header, BCF_DT_ID, input_field_idx));	//not NULL
+	  BOOST_CHECK(bcf_hdr_int2id(header, BCF_DT_ID, input_field_idx) != "");
+	  BOOST_CHECK_EQUAL(bcf_hdr_int2id(header, BCF_DT_ID, input_field_idx), combined_header.get_field_name(merged_field_idx));  
+	  auto lut_merged_field_idx = merger.get_merged_header_idx_for_input(input_vcf_idx, input_field_idx);
+	  BOOST_CHECK_EQUAL(lut_merged_field_idx, static_cast<int>(merged_field_idx));
+	  ++test_path_counters[INPUT_FIELD_VALID];
+	}
+	auto enum_value = merger.get_enum_for_merged_field_idx(merged_field_idx);
+	switch(enum_value)
+	{
+	  case PL_FIELD:
+	    BOOST_CHECK_EQUAL(combined_header.get_field_name(merged_field_idx), "PL");
+	    BOOST_CHECK_EQUAL(merged_field_idx, merger.get_merged_field_idx_for_enum(enum_value));
+	    ++test_path_counters[PL_ENUM_VALID];
+	    break;
+	  case AD_FIELD:
+	    BOOST_CHECK_EQUAL(combined_header.get_field_name(merged_field_idx), "AD");
+	    BOOST_CHECK_EQUAL(merged_field_idx, merger.get_merged_field_idx_for_enum(enum_value));
+	    ++test_path_counters[AD_ENUM_VALID];
+	    break;
+	  case 100:
+	    BOOST_CHECK_EQUAL(combined_header.get_field_name(merged_field_idx), "AF");
+	    BOOST_CHECK_EQUAL(merged_field_idx, merger.get_merged_field_idx_for_enum(enum_value));
+	    ++test_path_counters[AF_ENUM_VALID];
+	    break;
+	  default:
+	    const auto& field_name = combined_header.get_field_name(merged_field_idx);
+	    BOOST_CHECK(field_name != "AF" && field_name != "AD" && field_name != "PL");
+	    BOOST_CHECK_MESSAGE(enum_value == gamgee::missing_values::int32,
+		"Valid enum mapping "<<enum_value<<" should not exist for field "<<field_name);
+	    ++test_path_counters[INVALID_ENUM_INVALID];
+	    break;
+	}
+      }
+  }
+  //Same check for samples
+  for(auto merged_sample_idx=0u;merged_sample_idx<combined_header.n_samples();++merged_sample_idx)
+  {
+    auto input_sample_idx = merger.get_input_sample_idx_for_merged(input_vcf_idx, merged_sample_idx);
+    auto header_sample_idx = bcf_hdr_id2int(header.get(), BCF_DT_SAMPLE, combined_header.get_sample_name(merged_sample_idx).c_str());
+    if(gamgee::missing(input_sample_idx))
+    {
+      BOOST_CHECK_EQUAL(header_sample_idx, -1);
+      ++test_path_counters[INPUT_SAMPLE_MISSING];
+    }
+    else
+    {
+      BOOST_CHECK_EQUAL(header_sample_idx, input_sample_idx);
+      BOOST_CHECK(header->samples[input_sample_idx]);	//not null
+      BOOST_CHECK(header->samples[input_sample_idx] != "");
+      BOOST_CHECK_EQUAL(header->samples[input_sample_idx], combined_header.get_sample_name(merged_sample_idx));
+      auto lut_merged_sample_idx = merger.get_merged_sample_idx_for_input(input_vcf_idx, input_sample_idx);
+      BOOST_CHECK_EQUAL(lut_merged_sample_idx, merged_sample_idx);
+      ++test_path_counters[INPUT_SAMPLE_VALID];
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE( variant_header_merger_test )
+{
+  auto diff_hdr_test_files = vector<string>{ "testdata/ref_block/problem2_file2.vcf", "testdata/ref_block/test2.vcf",
+    "testdata/var_hdr_merge/test1.vcf" };
+  auto variant_header_merger_test_path_counters = vector<unsigned>(TOTAL_NUM_VARIANT_HEADER_MERGER_TEST_PATHS, 0u);
+  for(auto const & multi_reader : { GVCFReader{test_files, false}, GVCFReader{diff_hdr_test_files, false}  })
+  {
+    const vector<shared_ptr<bcf_hdr_t>>& header_vec = multi_reader.get_input_vcf_headers();
+    const VariantHeader& combined_header = multi_reader.combined_header();
+    //Duplicate hdr for testing FieldOrderedVariantHeaderMerger
+    FieldOrderedVariantHeaderMerger field_ordered_merger;
+    field_ordered_merger.add_headers(header_vec);
+    VariantHeader duplicate_combined_header { field_ordered_merger.get_raw_merged_header() };
+
+    InputOrderedVariantHeaderMerger& input_ordered_merger = 
+      (const_cast<GVCFReader&>(multi_reader)).get_variant_header_merger();
+    auto input_vcf_idx = 0u;
+    for(auto& header : header_vec)
+    {
+      //Merged header should contain every sample and header field in input header
+      for(auto i=0u;i<header->n[BCF_DT_ID];++i)
+	for(auto field_type : {BCF_HL_FLT, BCF_HL_INFO, BCF_HL_FMT})
+	  if(bcf_hdr_idinfo_exists(header,field_type, i) && bcf_hdr_id2hrec(header,BCF_DT_ID,field_type,i))
+	    BOOST_CHECK(combined_header.has_field(bcf_hdr_int2id(header,BCF_DT_ID,i), field_type));
+      for(auto i=0u;i<header->n[BCF_DT_SAMPLE];++i)
+	if(header->samples[i] && bcf_hdr_id2int(header.get(), BCF_DT_SAMPLE, header->samples[i]) == i)
+	  BOOST_CHECK(combined_header.has_sample(header->samples[i]));
+      test_variant_header_merger<InputOrderedVariantHeaderMerger>(input_ordered_merger, combined_header, header, input_vcf_idx,
+	  variant_header_merger_test_path_counters);
+      test_variant_header_merger<FieldOrderedVariantHeaderMerger>(field_ordered_merger, duplicate_combined_header, header, input_vcf_idx,
+	  variant_header_merger_test_path_counters);
+      ++input_vcf_idx;
+    }
+  }
+  for(auto i=0u;i<variant_header_merger_test_path_counters.size();++i)
+    BOOST_CHECK_MESSAGE(variant_header_merger_test_path_counters[i] > 0u, "VariantHeaderMerger test path corresponding to "<<i<<" was not exercised\n");
+}
+
 BOOST_AUTO_TEST_CASE( reference_block_iterator_move_test ) {
   auto reader0 = MultipleVariantReader<ReferenceBlockSplittingVariantIterator>{test_files, false};
   auto iter0 = reader0.begin();


### PR DESCRIPTION
1. Added MergedVCFLUT capability in utils/merged_vcf_utils.*. This class is now used within MultipleVariantReader.
2. Added test case for LUT.
3. Fixed signed-unsigned comparisons
4. Added some useful functions in VariantHeader

TODO:
1. What should be done when sample names are duplicated?
