### PR TITLE
VariantBuilderMultiSampleVector: simple class to make it easier to prepare multi-sample data for VariantBuilder

### DIFF
--- a/gamgee/CMakeLists.txt
+++ b/gamgee/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SOURCE_FILES
     variant_builder_individual_field.h
     variant_builder_individual_region.cpp
     variant_builder_individual_region.h
+    variant_builder_multi_sample_vector.h
     variant_builder_shared_region.cpp
     variant_builder_shared_region.h
     variant.cpp

--- a/gamgee/gamgee.h
+++ b/gamgee/gamgee.h
@@ -48,6 +48,7 @@
 #include "variant_builder.h"
 #include "variant_builder_individual_field.h"
 #include "variant_builder_individual_region.h"
+#include "variant_builder_multi_sample_vector.h"
 #include "variant_builder_shared_region.h"
 #include "variant_filters.h"
 #include "variant_filters_iterator.h"

--- a/gamgee/genotype.h
+++ b/gamgee/genotype.h
@@ -7,6 +7,7 @@
 #include "utils/utils.h"
 #include "utils/variant_field_type.h"
 #include "utils/genotype_utils.h"
+#include "variant_builder_multi_sample_vector.h"
 
 #include <memory>
 #include <utility>
@@ -277,7 +278,7 @@ class Genotype{
 
   /**
    * @brief Converts a vector of allele indices representing a genotype into BCF-encoded
-   *        format suitable for passing to VariantBuilder::set_genotypes(). No phasing
+   *        format suitable for passing to VariantBuilder::set_genotype(). No phasing
    *        is added.
    *
    *        Example: if you want to encode the genotype 0/1, create a vector with {0, 1}
@@ -289,7 +290,7 @@ class Genotype{
 
   /**
    * @brief Converts a vector of allele indices representing a genotype into BCF-encoded
-   *        format suitable for passing to VariantBuilder::set_genotypes(), and also
+   *        format suitable for passing to VariantBuilder::set_genotype(), and also
    *        allows you to phase all alleles
    *
    *        Example: if you want to encode the genotype 0|1, create a vector with {0, 1}
@@ -310,7 +311,7 @@ class Genotype{
 
   /**
    * @brief Converts multiple vectors of allele indices representing genotypes into
-   *        BCF_encoded format suitable for passing to VariantBuilder::set_genotypes().
+   *        BCF-encoded format suitable for passing to VariantBuilder::set_genotypes().
    *        No phasing is added.
    *
    *        Example: if you want to encode the genotypes 0/1 and 1/1, create a vector
@@ -320,6 +321,16 @@ class Genotype{
     for ( auto& genotype : multiple_genotypes ) {
       encode_genotype(genotype, false);
     }
+  }
+
+  /**
+   * @brief Converts multiple genotypes stored in a VariantBuilderMultiSampleVector into
+   *        BCF-encoded format suitable for passing to VariantBuilder::set_genotypes().
+   *        No phasing is added.
+   */
+  static inline void encode_genotypes(VariantBuilderMultiSampleVector<int32_t>& multiple_genotypes) {
+    auto& genotypes_vector = const_cast<std::vector<int32_t>&>(multiple_genotypes.get_vector());
+    encode_genotype(genotypes_vector, false);
   }
 
  private:

--- a/gamgee/variant_builder.cpp
+++ b/gamgee/variant_builder.cpp
@@ -218,13 +218,15 @@ VariantBuilder& VariantBuilder::remove_shared_fields(const std::vector<uint32_t>
  *
  ******************************************************************************/
 
-VariantBuilder& VariantBuilder::set_genotypes(const std::vector<int32_t>& genotypes_for_all_samples) {
-  m_individual_region.bulk_set_integer_field(m_individual_region.gt_index(), genotypes_for_all_samples);
+VariantBuilder& VariantBuilder::set_genotypes(const VariantBuilderMultiSampleVector<int32_t>& genotypes_for_all_samples) {
+  // Ensure that we have an lvalue reference to the genotypes vector so that we make a copy further down the line
+  const auto& genotypes_vector = genotypes_for_all_samples.get_vector();
+  m_individual_region.bulk_set_integer_field(m_individual_region.gt_index(), genotypes_vector);
   return *this;
 }
 
-VariantBuilder& VariantBuilder::set_genotypes(std::vector<int32_t>&& genotypes_for_all_samples) {
-  m_individual_region.bulk_set_integer_field(m_individual_region.gt_index(), move(genotypes_for_all_samples));
+VariantBuilder& VariantBuilder::set_genotypes(VariantBuilderMultiSampleVector<int32_t>&& genotypes_for_all_samples) {
+  m_individual_region.bulk_set_integer_field(m_individual_region.gt_index(), move(genotypes_for_all_samples.get_vector()));
   return *this;
 }
 
@@ -238,13 +240,15 @@ VariantBuilder& VariantBuilder::set_genotypes(std::vector<std::vector<int32_t>>&
   return *this;
 }
 
-VariantBuilder& VariantBuilder::set_integer_individual_field(const std::string& tag, const std::vector<int32_t>& values_for_all_samples) {
-  m_individual_region.bulk_set_integer_field(tag, values_for_all_samples);
+VariantBuilder& VariantBuilder::set_integer_individual_field(const std::string& tag, const VariantBuilderMultiSampleVector<int32_t>& values_for_all_samples) {
+  // Ensure that we have an lvalue reference to the values vector so that we make a copy further down the line
+  const auto& values_vector = values_for_all_samples.get_vector();
+  m_individual_region.bulk_set_integer_field(tag, values_vector);
   return *this;
 }
 
-VariantBuilder& VariantBuilder::set_integer_individual_field(const std::string& tag, std::vector<int32_t>&& values_for_all_samples) {
-  m_individual_region.bulk_set_integer_field(tag, move(values_for_all_samples));
+VariantBuilder& VariantBuilder::set_integer_individual_field(const std::string& tag, VariantBuilderMultiSampleVector<int32_t>&& values_for_all_samples) {
+  m_individual_region.bulk_set_integer_field(tag, move(values_for_all_samples.get_vector()));
   return *this;
 }
 
@@ -258,13 +262,15 @@ VariantBuilder& VariantBuilder::set_integer_individual_field(const std::string& 
   return *this;
 }
 
-VariantBuilder& VariantBuilder::set_integer_individual_field(const uint32_t field_index, const std::vector<int32_t>& values_for_all_samples) {
-  m_individual_region.bulk_set_integer_field(field_index, values_for_all_samples);
+VariantBuilder& VariantBuilder::set_integer_individual_field(const uint32_t field_index, const VariantBuilderMultiSampleVector<int32_t>& values_for_all_samples) {
+  // Ensure that we have an lvalue reference to the values vector so that we make a copy further down the line
+  const auto& values_vector = values_for_all_samples.get_vector();
+  m_individual_region.bulk_set_integer_field(field_index, values_vector);
   return *this;
 }
 
-VariantBuilder& VariantBuilder::set_integer_individual_field(const uint32_t field_index, std::vector<int32_t>&& values_for_all_samples) {
-  m_individual_region.bulk_set_integer_field(field_index, move(values_for_all_samples));
+VariantBuilder& VariantBuilder::set_integer_individual_field(const uint32_t field_index, VariantBuilderMultiSampleVector<int32_t>&& values_for_all_samples) {
+  m_individual_region.bulk_set_integer_field(field_index, move(values_for_all_samples.get_vector()));
   return *this;
 }
 
@@ -278,13 +284,15 @@ VariantBuilder& VariantBuilder::set_integer_individual_field(const uint32_t fiel
   return *this;
 }
 
-VariantBuilder& VariantBuilder::set_float_individual_field(const std::string& tag, const std::vector<float>& values_for_all_samples) {
-  m_individual_region.bulk_set_float_field(tag, values_for_all_samples);
+VariantBuilder& VariantBuilder::set_float_individual_field(const std::string& tag, const VariantBuilderMultiSampleVector<float>& values_for_all_samples) {
+  // Ensure that we have an lvalue reference to the values vector so that we make a copy further down the line
+  const auto& values_vector = values_for_all_samples.get_vector();
+  m_individual_region.bulk_set_float_field(tag, values_vector);
   return *this;
 }
 
-VariantBuilder& VariantBuilder::set_float_individual_field(const std::string& tag, std::vector<float>&& values_for_all_samples) {
-  m_individual_region.bulk_set_float_field(tag, move(values_for_all_samples));
+VariantBuilder& VariantBuilder::set_float_individual_field(const std::string& tag, VariantBuilderMultiSampleVector<float>&& values_for_all_samples) {
+  m_individual_region.bulk_set_float_field(tag, move(values_for_all_samples.get_vector()));
   return *this;
 }
 
@@ -298,13 +306,15 @@ VariantBuilder& VariantBuilder::set_float_individual_field(const std::string& ta
   return *this;
 }
 
-VariantBuilder& VariantBuilder::set_float_individual_field(const uint32_t field_index, const std::vector<float>& values_for_all_samples) {
-  m_individual_region.bulk_set_float_field(field_index, values_for_all_samples);
+VariantBuilder& VariantBuilder::set_float_individual_field(const uint32_t field_index, const VariantBuilderMultiSampleVector<float>& values_for_all_samples) {
+  // Ensure that we have an lvalue reference to the values vector so that we make a copy further down the line
+  const auto& values_vector = values_for_all_samples.get_vector();
+  m_individual_region.bulk_set_float_field(field_index, values_vector);
   return *this;
 }
 
-VariantBuilder& VariantBuilder::set_float_individual_field(const uint32_t field_index, std::vector<float>&& values_for_all_samples) {
-  m_individual_region.bulk_set_float_field(field_index, move(values_for_all_samples));
+VariantBuilder& VariantBuilder::set_float_individual_field(const uint32_t field_index, VariantBuilderMultiSampleVector<float>&& values_for_all_samples) {
+  m_individual_region.bulk_set_float_field(field_index, move(values_for_all_samples.get_vector()));
   return *this;
 }
 
@@ -429,6 +439,28 @@ VariantBuilder& VariantBuilder::remove_individual_fields(const std::vector<uint3
   for_each(field_indices.begin(), field_indices.end(), [this](const uint32_t field_index){ m_individual_region.remove_individual_field(field_index); });
   return *this;
 }
+
+
+/******************************************************************************
+*
+* Data preparation functions for working with individual fields
+*
+******************************************************************************/
+
+VariantBuilderMultiSampleVector<int32_t> VariantBuilder::get_genotype_multi_sample_vector(const uint32_t num_samples, const uint32_t max_values_per_sample) const {
+  return VariantBuilderMultiSampleVector<int32_t>{num_samples, max_values_per_sample, -1, bcf_int32_vector_end};
+}
+
+VariantBuilderMultiSampleVector<int32_t> VariantBuilder::get_integer_multi_sample_vector(const uint32_t num_samples, const uint32_t max_values_per_sample) const {
+  return VariantBuilderMultiSampleVector<int32_t>{num_samples, max_values_per_sample, bcf_int32_missing, bcf_int32_vector_end};
+}
+
+VariantBuilderMultiSampleVector<float> VariantBuilder::get_float_multi_sample_vector(const uint32_t num_samples, const uint32_t max_values_per_sample) const {
+  auto float_missing = 0.0f; bcf_float_set_missing(float_missing);
+  auto float_vector_end = 0.0f; bcf_float_set_vector_end(float_vector_end);
+  return VariantBuilderMultiSampleVector<float>{num_samples, max_values_per_sample, float_missing, float_vector_end};
+}
+
 
 /******************************************************************************
  *

--- a/gamgee/variant_builder_multi_sample_vector.h
+++ b/gamgee/variant_builder_multi_sample_vector.h
@@ -1,0 +1,132 @@
+#ifndef gamgee__variant_builder_multi_sample_vector__guard
+#define gamgee__variant_builder_multi_sample_vector__guard
+
+#include <vector>
+#include <string>
+
+namespace gamgee {
+
+/**
+ * @brief Class that allows you to efficiently prepare multi-sample data for setting individual fields in VariantBuilder
+ *
+ * For those who want higher performance than is possible with the vector<vector> individual field setters
+ * in VariantBuilder, this class is available as an alternative. Internally it uses a flattened, pre-padded
+ * one-dimensional vector that can be passed directly to htslib for encoding, and so has much better
+ * data locality and cache performance than a two-dimensional vector.
+ *
+ * To use, first determine the number of samples and the maximum number of values per
+ * sample for the field. Then get a pre-initialized VariantBuilderMultiSampleVector
+ * from your VariantBuilder instance. Eg.,
+ *
+ * auto multi_sample_vector = builder.get_integer_multi_sample_vector(num_samples, max_values_per_sample);
+ *
+ * (NOTE: DO NOT INSTANTIATE THIS CLASS DIRECTLY! ALWAYS GET AN INSTANCE FROM A VARIANTBUILDER OBJECT)
+ *
+ * This multi_sample_vector will have missing values for all samples, with appropriate padding to the
+ * maximum field width.
+ *
+ * Then, fill in the values for each non-missing sample by invoking the set_sample_value() and/or
+ * set_sample_values() functions on your multi-sample vector (NOTE: set_sample_value() is MUCH more efficient
+ * than set_sample_values() since it doesn't require a vector construction/destruction for each call).
+ * You don't have to worry about samples with no values, since all samples start out with missing values.
+ *
+ * Finally, pass your multi-sample vector into a VariantBuilder setter function (favoring the functions
+ * that take field indices and use move semantics for high performance). Eg.,
+ *
+ * builder.set_integer_individual_field(field_index, std::move(multi_sample_vector));
+ */
+template<class ELEMENT_TYPE>
+class VariantBuilderMultiSampleVector {
+ public:
+
+  /**
+   * @brief Construct a VariantBuilderMultiSampleVector
+   *
+   * @param num_samples number of samples we will be storing in this vector
+   * @param max_values_per_sample maximum number of values across all samples
+   * @param missing_value the BCF missing value for this type
+   * @param end_of_vector_value the BCF end of vector value for this type
+   *
+   * @note: DO NOT INSTANTIATE THIS CLASS DIRECTLY! ALWAYS GET AN INSTANCE FROM A VARIANTBUILDER OBJECT
+   */
+  VariantBuilderMultiSampleVector(const uint32_t num_samples, const uint32_t max_values_per_sample, const ELEMENT_TYPE missing_value, const ELEMENT_TYPE end_of_vector_value) :
+    m_multi_sample_values(num_samples * max_values_per_sample, end_of_vector_value),  // Fill with end_of_vector_value
+    m_num_samples{num_samples},
+    m_max_values_per_sample{max_values_per_sample}
+  {
+    // Place a single missing value at the start of each sample's values (the rest of the vector has already
+    // been padded with vector end values)
+    for ( auto sample_start = 0u; sample_start < m_multi_sample_values.size(); sample_start += m_max_values_per_sample ) {
+      m_multi_sample_values[sample_start] = missing_value;
+    }
+  }
+
+  // Moveable but not copyable, with default destruction
+  VariantBuilderMultiSampleVector(const VariantBuilderMultiSampleVector& other) = delete;
+  VariantBuilderMultiSampleVector& operator=(const VariantBuilderMultiSampleVector& other) = delete;
+  VariantBuilderMultiSampleVector(VariantBuilderMultiSampleVector&& other) = default;
+  VariantBuilderMultiSampleVector& operator=(VariantBuilderMultiSampleVector&& other) = default;
+  ~VariantBuilderMultiSampleVector() = default;
+
+  /**
+   * @brief Set a single value for one sample
+   *
+   * @param sample_index index of the sample (from a VariantHeader lookup)
+   * @param value_index index of the value we are setting for this sample (values for EACH sample start at index 0)
+   * @param value value to set
+   *
+   * @note MUCH more efficient than set_sample_values() below, since it doesn't require a vector
+   *       construction/destruction for each call.
+   *
+   * @warning NO bounds checking is performed (for the sake of performance), so be sure that sample_index
+   *          is < num_samples and value_index < max_values_per_sample
+   */
+  inline void set_sample_value(const uint32_t sample_index, const uint32_t value_index, const ELEMENT_TYPE value) {
+    m_multi_sample_values[sample_index * m_max_values_per_sample + value_index] = value;
+  }
+
+  /**
+   * @brief Set all values for one sample at once
+   *
+   * @param sample_index index of the sample (from a VariantHeader lookup)
+   * @param values vector of values for this sample
+   *
+   * @note LESS efficient than setting one value at a time using set_sample_value(), since this function
+   *       involves creating/destroying a vector for each sample.
+   *
+   * @warning NO bounds checking is performed (for the sake of performance), so be sure that sample_index
+   *          is < num_samples and values.size() <= max_values_per_sample
+   */
+  inline void set_sample_values(const uint32_t sample_index, const std::vector<ELEMENT_TYPE>& values) {
+    const auto sample_start = sample_index * m_max_values_per_sample;
+    for ( auto value_index = 0u; value_index < values.size(); ++value_index ) {
+      m_multi_sample_values[sample_start + value_index] = values[value_index];
+    }
+  }
+
+  /**
+   * @brief Get a reference to the internal one-dimensional vector used for value storage
+   */
+  const std::vector<ELEMENT_TYPE>& get_vector() const { return m_multi_sample_values; }
+
+  /**
+   * @brief Return the number of samples whose values we are storing
+   */
+  uint32_t num_samples() const { return m_num_samples; }
+
+  /**
+   * @brief Return the maximum number of values across all samples
+   */
+  uint32_t max_values_per_sample() const { return m_max_values_per_sample; }
+
+ private:
+  std::vector<ELEMENT_TYPE> m_multi_sample_values;
+  uint32_t m_num_samples;
+  uint32_t m_max_values_per_sample;
+
+  friend class VariantBuilder; // VariantBuilder needs access to internals in order to build efficiently
+};
+
+}
+
+#endif  /* gamgee__variant_builder_multi_sample_vector__guard */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCE_FILES
     select_if_test.cpp
     short_value_optimized_storage_test.cpp
     utils_test.cpp
+    variant_builder_multi_sample_vector_test.cpp
     variant_builder_test.cpp
     variant_header_test.cpp
     variant_reader_test.cpp

--- a/test/variant_builder_multi_sample_vector_test.cpp
+++ b/test/variant_builder_multi_sample_vector_test.cpp
@@ -1,0 +1,130 @@
+#include "variant_builder_multi_sample_vector.h"
+#include "variant.h"
+
+#include <boost/test/unit_test.hpp>
+#include <stdexcept>
+
+using namespace std;
+using namespace gamgee;
+
+// Input and expected output for both test_integer_multi_sample_vector_multiple_samples and test_integer_multi_sample_vector_multiple_samples_bulk_setting
+const static auto multi_sample_tests_input_values = vector<vector<int32_t>>{ {1, 2, 3}, {1, 2}, {1}, {} };
+const static auto multi_sample_tests_expected_output = vector<int32_t>{1, 2, 3, 1, 2, bcf_int32_vector_end, 1, bcf_int32_vector_end, bcf_int32_vector_end, bcf_int32_missing, bcf_int32_vector_end, bcf_int32_vector_end};
+
+BOOST_AUTO_TEST_CASE( test_integer_multi_sample_vector_multiple_samples ) {
+  // 4 samples, max of 3 values per sample
+  const auto num_samples = 4u;
+  const auto max_values_per_sample = 3u;
+  auto vec = VariantBuilderMultiSampleVector<int32_t>{num_samples, max_values_per_sample, bcf_int32_missing, bcf_int32_vector_end};
+
+  for ( auto sample_index = 0u; sample_index < multi_sample_tests_input_values.size(); ++sample_index ) {
+    // Set each value for each sample individually
+    for ( auto value_index = 0u; value_index < multi_sample_tests_input_values[sample_index].size(); ++value_index ) {
+      vec.set_sample_value(sample_index, value_index, multi_sample_tests_input_values[sample_index][value_index]);
+    }
+  }
+
+  BOOST_CHECK_EQUAL(vec.num_samples(), num_samples);
+  BOOST_CHECK_EQUAL(vec.max_values_per_sample(), max_values_per_sample);
+  BOOST_CHECK_EQUAL(multi_sample_tests_expected_output.size(), vec.get_vector().size());
+  auto output_vector = vec.get_vector();
+  for ( auto i = 0u; i < multi_sample_tests_expected_output.size(); ++i ) {
+    BOOST_CHECK_EQUAL(multi_sample_tests_expected_output[i], output_vector[i]);
+  }
+}
+
+BOOST_AUTO_TEST_CASE( test_integer_multi_sample_vector_multiple_samples_bulk_setting ) {
+  // 4 samples, max of 3 values per sample
+  const auto num_samples = 4u;
+  const auto max_values_per_sample = 3u;
+  auto vec = VariantBuilderMultiSampleVector<int32_t>{num_samples, max_values_per_sample, bcf_int32_missing, bcf_int32_vector_end};
+
+  for ( auto sample_index = 0u; sample_index < multi_sample_tests_input_values.size(); ++sample_index ) {
+    // Set all values for each sample at once
+    vec.set_sample_values(sample_index, multi_sample_tests_input_values[sample_index]);
+  }
+
+  BOOST_CHECK_EQUAL(vec.num_samples(), num_samples);
+  BOOST_CHECK_EQUAL(vec.max_values_per_sample(), max_values_per_sample);
+  BOOST_CHECK_EQUAL(multi_sample_tests_expected_output.size(), vec.get_vector().size());
+  auto output_vector = vec.get_vector();
+  for ( auto i = 0u; i < multi_sample_tests_expected_output.size(); ++i ) {
+    BOOST_CHECK_EQUAL(multi_sample_tests_expected_output[i], output_vector[i]);
+  }
+}
+
+BOOST_AUTO_TEST_CASE( test_integer_multi_sample_vector_one_sample ) {
+  // 1 sample, max of 3 values per sample
+  const auto num_samples = 1u;
+  const auto max_values_per_sample = 3u;
+  auto vec = VariantBuilderMultiSampleVector<int32_t>{num_samples, max_values_per_sample, bcf_int32_missing, bcf_int32_vector_end};
+  auto input_values = vector<int32_t>{1, 2};
+  auto expected_output = vector<int32_t>{1, 2, bcf_int32_vector_end};
+
+  vec.set_sample_values(0, input_values);
+
+  BOOST_CHECK_EQUAL(vec.num_samples(), num_samples);
+  BOOST_CHECK_EQUAL(vec.max_values_per_sample(), max_values_per_sample);
+  BOOST_CHECK_EQUAL(expected_output.size(), vec.get_vector().size());
+  auto output_vector = vec.get_vector();
+  for ( auto i = 0u; i < expected_output.size(); ++i ) {
+    BOOST_CHECK_EQUAL(expected_output[i], output_vector[i]);
+  }
+}
+
+BOOST_AUTO_TEST_CASE( test_integer_multi_sample_vector_single_valued_field ) {
+  // 4 samples, max of 1 value per sample
+  const auto num_samples = 4u;
+  const auto max_values_per_sample = 1u;
+  auto vec = VariantBuilderMultiSampleVector<int32_t>{num_samples, max_values_per_sample, bcf_int32_missing, bcf_int32_vector_end};
+  auto input_values = vector<vector<int32_t>>{ {1}, {2}, {}, {3} };
+  auto expected_output = vector<int32_t>{1, 2, bcf_int32_missing, 3};
+
+  for ( auto sample_index = 0u; sample_index < input_values.size(); ++sample_index ) {
+    // Set all values for each sample at once
+    vec.set_sample_values(sample_index, input_values[sample_index]);
+  }
+
+  BOOST_CHECK_EQUAL(vec.num_samples(), num_samples);
+  BOOST_CHECK_EQUAL(vec.max_values_per_sample(), max_values_per_sample);
+  BOOST_CHECK_EQUAL(expected_output.size(), vec.get_vector().size());
+  auto output_vector = vec.get_vector();
+  for ( auto i = 0u; i < expected_output.size(); ++i ) {
+    BOOST_CHECK_EQUAL(expected_output[i], output_vector[i]);
+  }
+}
+
+BOOST_AUTO_TEST_CASE( test_float_multi_sample_vector_multiple_samples ) {
+  auto float_missing = 0.0f; bcf_float_set_missing(float_missing);
+  auto float_vector_end = 0.0f; bcf_float_set_vector_end(float_vector_end);
+
+  // 4 samples, max of 3 values per sample
+  const auto num_samples = 4u;
+  const auto max_values_per_sample = 3u;
+  auto vec = VariantBuilderMultiSampleVector<float>{num_samples, max_values_per_sample, float_missing, float_vector_end};
+  auto input_values = vector<vector<float>>{ {1.5, 2.5, 3.5}, {1.5, 2.5}, {1.5}, {} };
+  auto expected_output = vector<float>{1.5, 2.5, 3.5, 1.5, 2.5, float_vector_end, 1.5, float_vector_end, float_vector_end, float_missing, float_vector_end, float_vector_end};
+
+  for ( auto sample_index = 0u; sample_index < input_values.size(); ++sample_index ) {
+    // Set each value for each sample individually
+    for ( auto value_index = 0u; value_index < input_values[sample_index].size(); ++value_index ) {
+      vec.set_sample_value(sample_index, value_index, input_values[sample_index][value_index]);
+    }
+  }
+
+  BOOST_CHECK_EQUAL(vec.num_samples(), num_samples);
+  BOOST_CHECK_EQUAL(vec.max_values_per_sample(), max_values_per_sample);
+  BOOST_CHECK_EQUAL(expected_output.size(), vec.get_vector().size());
+  auto output_vector = vec.get_vector();
+  for ( auto i = 0u; i < expected_output.size(); ++i ) {
+    if ( bcf_float_is_missing(expected_output[i]) ) {
+      BOOST_CHECK(bcf_float_is_missing(output_vector[i]));
+    }
+    else if ( bcf_float_is_vector_end(expected_output[i]) ) {
+      BOOST_CHECK(bcf_float_is_vector_end(output_vector[i]));
+    }
+    else {
+      BOOST_CHECK_EQUAL(expected_output[i], output_vector[i]);
+    }
+  }
+}


### PR DESCRIPTION
Made the efficient one-dimensional vector option for setting individual fields MUCH easier
to use by providing a VariantBuilderMultiSampleVector class that handles the work of
setting missing values and padding the vector to the maximum field width.

To use, first determine the number of samples and the maximum number of values per sample
for the field, then get a pre-initialized vector from the builder. Eg.,

auto multi_sample_vector = builder.get_integer_multi_sample_vector(num_samples, max_values_per_sample);

This vector will have missing values for all samples, with appropriate padding to the maximum field width.

Then, fill in the values for each non-missing sample by invoking the set_sample_value() and/or
set_sample_values() functions on your multi-sample vector (set_sample_value() is more efficient
than set_sample_values() since it doesn't require a vector construction/destruction for each call).
You don't have to worry about samples with no values, since all samples start out with missing values.

Finally, pass your multi-sample vector to the builder (ideally by move):

builder.set_integer_individual_field(field_index, std::move(multi_sample_vector));

-Works with integer and float individual fields, as well as the GT field
 (string fields are still set by passing in a one-dimensional vector of strings).

-Removed the ability to pass in a raw one-dimensional vector directly for int/float
 fields -- you must use a VariantBuilderMultiSampleVector if you want to work
 with flattened multi-sample data.

-Updated tests as necessary.

Resolves #325
