### PR TITLE
MVI and RBSVI now output pairs with file indices

### DIFF
--- a/gamgee/multiple_variant_iterator.cpp
+++ b/gamgee/multiple_variant_iterator.cpp
@@ -2,27 +2,22 @@
 
 namespace gamgee {
 
-MultipleVariantIterator::MultipleVariantIterator() :
-  m_queue {},
-  m_variant_vector {}
-{}
-
 MultipleVariantIterator::MultipleVariantIterator(const std::vector<std::shared_ptr<htsFile>>& variant_files, const std::vector<std::shared_ptr<bcf_hdr_t>>& variant_headers) :
   m_queue {},
   m_variant_vector {}
 {
   m_variant_vector.reserve(variant_files.size());
   for (auto i = 0u; i < variant_files.size(); i++) {
-    m_queue.push(std::make_shared<VariantIterator>(variant_files[i], variant_headers[i]));
+    m_queue.push(VariantIteratorIndexPair{std::make_shared<VariantIterator>(variant_files[i], variant_headers[i]), i});
   }
   fetch_next_vector();
 }
 
-std::vector<Variant>& MultipleVariantIterator::operator*() {
+std::vector<VariantIndexPair>& MultipleVariantIterator::operator*() {
   return m_variant_vector;
 }
 
-std::vector<Variant>& MultipleVariantIterator::operator++() {
+std::vector<VariantIndexPair>& MultipleVariantIterator::operator++() {
   fetch_next_vector();
   return m_variant_vector;
 }
@@ -33,14 +28,14 @@ bool MultipleVariantIterator::operator!=(const MultipleVariantIterator& rhs) {
   return !(m_variant_vector.empty() && rhs.m_variant_vector.empty());
 }
 
-bool MultipleVariantIterator::Comparator::operator()(const std::shared_ptr<VariantIterator>& left, const std::shared_ptr<VariantIterator>& right) {
-  if ((**left).chromosome() > (**right).chromosome())
+bool MultipleVariantIterator::Comparator::operator()(const VariantIteratorIndexPair& left, const VariantIteratorIndexPair& right) {
+  if ((**(left.first)).chromosome() > (**(right.first)).chromosome())
     return true;
 
-  if ((**left).chromosome() < (**right).chromosome())
+  if ((**(left.first)).chromosome() < (**(right.first)).chromosome())
     return false;
 
-  return (**left).alignment_start() > (**right).alignment_start();
+  return (**(left.first)).alignment_start() > (**(right.first)).alignment_start();
 }
 
 void MultipleVariantIterator::fetch_next_vector() {
@@ -49,20 +44,21 @@ void MultipleVariantIterator::fetch_next_vector() {
   auto current_start = 0u;
 
   while (!m_queue.empty()) {
-    const auto top_iterator = m_queue.top();
+    const auto top_queue_elem = m_queue.top();
+    const auto top_iterator = top_queue_elem.first;
     const auto& variant = **top_iterator;
 
     if (!m_variant_vector.empty() && !(variant.chromosome() == current_chrom && variant.alignment_start() == current_start))
       break;
     else {
-      m_variant_vector.push_back(variant);
       current_chrom = variant.chromosome();
       current_start = variant.alignment_start();
+      m_variant_vector.push_back(VariantIndexPair{variant, top_queue_elem.second});
 
       m_queue.pop();
       top_iterator->operator++();
       if (! top_iterator->empty())
-        m_queue.push(std::move(top_iterator));
+        m_queue.push(std::move(top_queue_elem));
     }
   }
 }

--- a/gamgee/multiple_variant_iterator.h
+++ b/gamgee/multiple_variant_iterator.h
@@ -11,6 +11,9 @@
 
 namespace gamgee {
 
+using VariantIteratorIndexPair = std::pair<std::shared_ptr<VariantIterator>, uint32_t>;
+using VariantIndexPair = std::pair<Variant, uint32_t>;
+
 /**
  * @brief Utility class to enable for-each style iteration in the MultipleVariantReader class
  */
@@ -20,7 +23,7 @@ class MultipleVariantIterator {
   /**
    * @brief creates an empty iterator (used for the end() method) 
    */
-  MultipleVariantIterator();
+  MultipleVariantIterator() = default;
 
   /**
    * @brief initializes a new iterator based on a vector of input files (vcf or bcf)
@@ -59,14 +62,14 @@ class MultipleVariantIterator {
    *
    * @return a reference to the iterator's Variant vector
    */
-  std::vector<Variant>& operator*();
+  std::vector<VariantIndexPair>& operator*();
 
   /**
    * @brief advances the iterator, fetching the next vector
    *
    * @return a reference to the iterator's Variant vector
    */
-  std::vector<Variant>& operator++();
+  std::vector<VariantIndexPair>& operator++();
 
  private:
   // fetches the next Variant vector
@@ -75,14 +78,14 @@ class MultipleVariantIterator {
   // comparison class for genomic locations in the priority queue
   class Comparator {
    public:
-    bool operator()(const std::shared_ptr<VariantIterator>& left, const std::shared_ptr<VariantIterator>& right);
+    bool operator()(const VariantIteratorIndexPair& left, const VariantIteratorIndexPair& right);
   };
 
   // the individual file iterators
-  std::priority_queue<std::shared_ptr<VariantIterator>, std::vector<std::shared_ptr<VariantIterator>>, Comparator> m_queue;
+  std::priority_queue<VariantIteratorIndexPair, std::vector<VariantIteratorIndexPair>, Comparator> m_queue;
 
   // caches next Variant vector
-  std::vector<Variant> m_variant_vector;
+  std::vector<VariantIndexPair> m_variant_vector;
 };
 
 }  // end namespace gamgee

--- a/gamgee/reference_block_splitting_variant_iterator.cpp
+++ b/gamgee/reference_block_splitting_variant_iterator.cpp
@@ -20,11 +20,11 @@ ReferenceBlockSplittingVariantIterator::ReferenceBlockSplittingVariantIterator(c
   fetch_next_split_vector();
 }
 
-std::vector<Variant>& ReferenceBlockSplittingVariantIterator::operator*() {
+std::vector<VariantIndexPair>& ReferenceBlockSplittingVariantIterator::operator*() {
   return m_split_variants;
 }
 
-std::vector<Variant>& ReferenceBlockSplittingVariantIterator::operator++() {
+std::vector<VariantIndexPair>& ReferenceBlockSplittingVariantIterator::operator++() {
   fetch_next_split_vector();
   return m_split_variants;
 }
@@ -37,9 +37,10 @@ bool ReferenceBlockSplittingVariantIterator::operator!=(const ReferenceBlockSpli
 }
 
 void ReferenceBlockSplittingVariantIterator::populate_pending () {
-  for (const auto& variant : MultipleVariantIterator::operator*()) {
+  for (const auto& variant_pair : MultipleVariantIterator::operator*()) {
+    const auto& variant = variant_pair.first;
     m_pending_min_end = std::min(m_pending_min_end, variant.alignment_stop());
-    m_pending_variants.push_back(std::move(variant));
+    m_pending_variants.push_back(std::move(variant_pair));
   }
 
   MultipleVariantIterator::operator++();
@@ -56,28 +57,30 @@ void ReferenceBlockSplittingVariantIterator::populate_split_variants () {
   //FIXME: should remove these checks to avoid overhead every time
   auto& next_pos_variant_vector = MultipleVariantIterator::operator*();
   if (!next_pos_variant_vector.empty()
-          && next_pos_variant_vector[0].chromosome() == m_pending_chrom
-          && next_pos_variant_vector[0].alignment_start() == m_pending_min_end+1
-          && !gamgee::missing(next_pos_variant_vector[0].ref()))
-    new_reference_allele = next_pos_variant_vector[0].ref()[0];	//only the first character is needed
+          && next_pos_variant_vector[0].first.chromosome() == m_pending_chrom
+          && next_pos_variant_vector[0].first.alignment_start() == m_pending_min_end+1
+          && !gamgee::missing(next_pos_variant_vector[0].first.ref()))
+    new_reference_allele = next_pos_variant_vector[0].first.ref()[0];	//only the first character is needed
 
   // the latter halves of split variants will return to pending
   // so we need to keep track of indices of the current and next pending vectors
   auto current_pending_index = 0u;
   auto next_pending_index = 0u;
 
-  for (auto& variant : m_pending_variants) {
+  for (auto& variant_pair : m_pending_variants) {
+    auto& variant = variant_pair.first;
     auto var_end = variant.alignment_stop();
     // don't split reference blocks which end at the correct point
     // or variants with actual alt alleles
     if (var_end == m_pending_min_end || variant.alt().size() > 1) {
-      m_split_variants.push_back(std::move(variant));
+      m_split_variants.push_back(std::move(variant_pair));
     }
     else {
       // this is a reference block that extends past the desired end, so copy and split it
-      auto split_variant = variant;
+      auto split_variant_pair = variant_pair;
+      auto& split_variant = split_variant_pair.first;
       split_variant.set_alignment_stop(m_pending_min_end);
-      m_split_variants.push_back(std::move(split_variant));
+      m_split_variants.push_back(std::move(split_variant_pair));
 
       new_pending_start = m_pending_min_end + 1;
       new_pending_end = std::min(new_pending_end, var_end);
@@ -87,7 +90,7 @@ void ReferenceBlockSplittingVariantIterator::populate_split_variants () {
 
       // check if variant is already in the right location
       if (next_pending_index != current_pending_index)
-        m_pending_variants[next_pending_index] = std::move(variant);
+        m_pending_variants[next_pending_index] = std::move(variant_pair);
 
       ++next_pending_index;
     }
@@ -110,16 +113,16 @@ void ReferenceBlockSplittingVariantIterator::fetch_next_split_vector() {
     auto& incoming = MultipleVariantIterator::operator*();
     // when the pending list is empty, fill from the incoming vector and consume it
     if (m_pending_variants.empty()) {
-      m_pending_chrom = incoming[0].chromosome();
-      m_pending_start = incoming[0].alignment_start();
+      m_pending_chrom = incoming[0].first.chromosome();
+      m_pending_start = incoming[0].first.alignment_start();
       m_pending_min_end = UINT_MAX;
       populate_pending();
     }
     else {
       // if the incoming vector has the same start location as pending, add it to pending and consume it
       if (!incoming.empty()
-          && incoming[0].chromosome() == m_pending_chrom
-          && incoming[0].alignment_start() == m_pending_start)
+          && incoming[0].first.chromosome() == m_pending_chrom
+          && incoming[0].first.alignment_start() == m_pending_start)
         populate_pending();
     }
 
@@ -127,8 +130,8 @@ void ReferenceBlockSplittingVariantIterator::fetch_next_split_vector() {
     incoming = MultipleVariantIterator::operator*();
 
     // if the pending Variants' end is after the incoming vector's start, then their end is too high
-    if (!incoming.empty() && incoming[0].chromosome() == m_pending_chrom)
-      m_pending_min_end = std::min(m_pending_min_end, incoming[0].alignment_start() - 1);
+    if (!incoming.empty() && incoming[0].first.chromosome() == m_pending_chrom)
+      m_pending_min_end = std::min(m_pending_min_end, incoming[0].first.alignment_start() - 1);
 
     populate_split_variants();
   }

--- a/gamgee/reference_block_splitting_variant_iterator.h
+++ b/gamgee/reference_block_splitting_variant_iterator.h
@@ -58,14 +58,14 @@ class ReferenceBlockSplittingVariantIterator : public MultipleVariantIterator {
    *
    * @return a reference to the iterator's Variant vector
    */
-  std::vector<Variant>& operator*();
+  std::vector<VariantIndexPair>& operator*();
 
   /**
    * @brief advances the iterator, fetching the next vector
    *
    * @return a reference to the iterator's Variant vector
    */
-  std::vector<Variant>& operator++();
+  std::vector<VariantIndexPair>& operator++();
 
  private:
   // fetches the next reference-block-split Variant vector
@@ -79,10 +79,10 @@ class ReferenceBlockSplittingVariantIterator : public MultipleVariantIterator {
   inline void populate_split_variants();
 
   // holds the incoming reference-block variants before and during split operations
-  std::vector<Variant> m_pending_variants;
+  std::vector<VariantIndexPair> m_pending_variants;
 
   // caches next reference-block-split Variant vector
-  std::vector<Variant> m_split_variants;
+  std::vector<VariantIndexPair> m_split_variants;
 
   unsigned int m_pending_chrom = UINT_MAX;
   unsigned int m_pending_start = UINT_MAX;


### PR DESCRIPTION
- Made MVI() explicitly default
- added some consts and refs to tests

Enables use of the LUT (#376) by associating an input file index with every Variant
