### PR TITLE
Prevent GT from being set using generic integer field setters

### DIFF
--- a/gamgee/variant_builder.cpp
+++ b/gamgee/variant_builder.cpp
@@ -224,7 +224,7 @@ VariantBuilder& VariantBuilder::set_genotypes(const VariantBuilderMultiSampleVec
   Genotype::encode_genotypes(encoded_genotypes);
 
   // We've made a copy, so we can move the copy into the storage layer
-  m_individual_region.bulk_set_integer_field(m_individual_region.gt_index(), move(encoded_genotypes.get_vector()));
+  m_individual_region.bulk_set_genotype_field(m_individual_region.gt_index(), move(encoded_genotypes.get_vector()));
   return *this;
 }
 
@@ -232,7 +232,7 @@ VariantBuilder& VariantBuilder::set_genotypes(VariantBuilderMultiSampleVector<in
   // Encode user's vector directly, since it's been moved in to us
   Genotype::encode_genotypes(genotypes_for_all_samples);
 
-  m_individual_region.bulk_set_integer_field(m_individual_region.gt_index(), move(genotypes_for_all_samples.get_vector()));
+  m_individual_region.bulk_set_genotype_field(m_individual_region.gt_index(), move(genotypes_for_all_samples.get_vector()));
   return *this;
 }
 
@@ -242,7 +242,7 @@ VariantBuilder& VariantBuilder::set_genotypes(const std::vector<std::vector<int3
   Genotype::encode_genotypes(encoded_genotypes);
 
   // We've made a copy, so we can move the copy into the storage layer
-  m_individual_region.bulk_set_integer_field(m_individual_region.gt_index(), move(encoded_genotypes));
+  m_individual_region.bulk_set_genotype_field(m_individual_region.gt_index(), move(encoded_genotypes));
   return *this;
 }
 
@@ -250,7 +250,7 @@ VariantBuilder& VariantBuilder::set_genotypes(std::vector<std::vector<int32_t>>&
   // Encode user's vector directly, since it's been moved in to us
   Genotype::encode_genotypes(genotypes_for_all_samples);
 
-  m_individual_region.bulk_set_integer_field(m_individual_region.gt_index(), move(genotypes_for_all_samples));
+  m_individual_region.bulk_set_genotype_field(m_individual_region.gt_index(), move(genotypes_for_all_samples));
   return *this;
 }
 
@@ -373,7 +373,7 @@ VariantBuilder& VariantBuilder::set_genotype(const std::string& sample, const st
   auto encoded_genotype = genotype;
   Genotype::encode_genotype(encoded_genotype);
 
-  m_individual_region.set_integer_field_by_sample(m_individual_region.gt_index(), sample, encoded_genotype.empty() ? nullptr : &(encoded_genotype[0]), encoded_genotype.size());
+  m_individual_region.set_genotype_field_by_sample(m_individual_region.gt_index(), sample, encoded_genotype.empty() ? nullptr : &(encoded_genotype[0]), encoded_genotype.size());
   return *this;
 }
 
@@ -381,7 +381,7 @@ VariantBuilder& VariantBuilder::set_genotype(const std::string& sample, std::vec
   // Encode user's vector directly, since it's been moved in to us
   Genotype::encode_genotype(genotype);
 
-  m_individual_region.set_integer_field_by_sample(m_individual_region.gt_index(), sample, genotype.empty() ? nullptr : &(genotype[0]), genotype.size());
+  m_individual_region.set_genotype_field_by_sample(m_individual_region.gt_index(), sample, genotype.empty() ? nullptr : &(genotype[0]), genotype.size());
   return *this;
 }
 
@@ -390,7 +390,7 @@ VariantBuilder& VariantBuilder::set_genotype(const uint32_t sample_index, const 
   auto encoded_genotype = genotype;
   Genotype::encode_genotype(encoded_genotype);
 
-  m_individual_region.set_integer_field_by_sample(m_individual_region.gt_index(), sample_index, encoded_genotype.empty() ? nullptr : &(encoded_genotype[0]), encoded_genotype.size());
+  m_individual_region.set_genotype_field_by_sample(m_individual_region.gt_index(), sample_index, encoded_genotype.empty() ? nullptr : &(encoded_genotype[0]), encoded_genotype.size());
   return *this;
 }
 
@@ -398,7 +398,7 @@ VariantBuilder& VariantBuilder::set_genotype(const uint32_t sample_index, std::v
   // Encode user's vector directly, since it's been moved in to us
   Genotype::encode_genotype(genotype);
 
-  m_individual_region.set_integer_field_by_sample(m_individual_region.gt_index(), sample_index, genotype.empty() ? nullptr : &(genotype[0]), genotype.size());
+  m_individual_region.set_genotype_field_by_sample(m_individual_region.gt_index(), sample_index, genotype.empty() ? nullptr : &(genotype[0]), genotype.size());
   return *this;
 }
 

--- a/gamgee/variant_builder_individual_region.cpp
+++ b/gamgee/variant_builder_individual_region.cpp
@@ -161,13 +161,13 @@ void VariantBuilderIndividualRegion::remove_field(const int32_t field_index) {
   }
 }
 
-void VariantBuilderIndividualRegion::validate_individual_field(const int32_t field_index, const uint32_t provided_type) const {
+void VariantBuilderIndividualRegion::validate_individual_field(const int32_t field_index, const uint32_t provided_type, const bool allow_gt) const {
   validate_individual_field_existence(field_index);
 
   // Special-case the GT field when doing type checking, since its nominal type in the header will be BCF_HT_STR,
-  // but we require integer data to encode it
+  // but we require integer data encoded via one of the genotype setter functions
   if ( field_index == m_gt_field_index ) {
-    if ( provided_type != BCF_HT_INT ) throw invalid_argument(string{"Type mismatch for GT field: integer data required"});
+    if ( ! allow_gt || provided_type != BCF_HT_INT ) throw invalid_argument(string{"Type mismatch for GT field: must set GT using a genotype-specific setter function, and provide integer data"});
   }
   else if ( m_header.individual_field_type(field_index) != provided_type ) {
     throw invalid_argument(string{"Type mismatch for individual field with index "} + to_string(field_index));
@@ -176,8 +176,8 @@ void VariantBuilderIndividualRegion::validate_individual_field(const int32_t fie
   // TODO: validate cardinality of the fields (must be done at build time, and could be expensive...)
 }
 
-void VariantBuilderIndividualRegion::validate_individual_field(const int32_t field_index, const int32_t sample_index, const uint32_t provided_type) const {
-  validate_individual_field(field_index, provided_type);
+void VariantBuilderIndividualRegion::validate_individual_field(const int32_t field_index, const int32_t sample_index, const uint32_t provided_type, const bool allow_gt) const {
+  validate_individual_field(field_index, provided_type, allow_gt);
 
   if ( ! m_header.has_sample(sample_index) ) {
     throw invalid_argument(string{"No sample with index "} + to_string(sample_index) + " found in builder's header");

--- a/test/variant_builder_test.cpp
+++ b/test/variant_builder_test.cpp
@@ -1280,6 +1280,16 @@ BOOST_AUTO_TEST_CASE( bulk_set_individual_field_type_mismatch ) {
   BOOST_CHECK_THROW(builder.set_string_individual_field(header.field_index("ZIFMT"), {"a", "b", "c"}), invalid_argument);
 }
 
+BOOST_AUTO_TEST_CASE( bulk_set_gt_using_generic_integer_setters ) {
+  auto header = SingleVariantReader{"testdata/test_variants_for_variantbuilder.vcf"}.header();
+  auto builder = VariantBuilder{header};
+  builder.set_chromosome(0).set_alignment_start(5).set_ref_allele("A");
+
+  // Setting GT using a generic integer field bulk setter should throw
+  BOOST_CHECK_THROW(builder.set_integer_individual_field("GT", vector<vector<int32_t>>{{1, 0}, {0, 1}, {1, 1}}), invalid_argument);
+  BOOST_CHECK_THROW(builder.set_integer_individual_field(header.field_index("GT"), vector<vector<int32_t>>{{1, 0}, {0, 1}, {1, 1}}), invalid_argument);
+}
+
 BOOST_AUTO_TEST_CASE( bulk_set_individual_field_bad_field_id ) {
   auto header = SingleVariantReader{"testdata/test_variants_for_variantbuilder.vcf"}.header();
   auto builder = VariantBuilder{header};
@@ -1724,6 +1734,16 @@ BOOST_AUTO_TEST_CASE( set_individual_field_by_sample_type_mismatch ) {
   BOOST_CHECK_THROW(builder.set_integer_individual_field("AF", sample_names[0], {1, 2}), invalid_argument);
   BOOST_CHECK_THROW(builder.set_float_individual_field("ZIFMT", sample_names[0], {1.5f, 2.5f}), invalid_argument);
   BOOST_CHECK_THROW(builder.set_string_individual_field("AF", sample_names[0], "abc"), invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE( set_genotype_field_by_sample_using_integer_setter ) {
+  auto header = SingleVariantReader{"testdata/test_variants_for_variantbuilder.vcf"}.header();
+  auto builder = VariantBuilder{header};
+  builder.set_chromosome(0).set_alignment_start(5).set_ref_allele("A");
+
+  // Attempting to set GT using a generic integer field setter should throw
+  BOOST_CHECK_THROW(builder.set_integer_individual_field("GT", "NA12878", vector<int32_t>{0, 1}), invalid_argument);
+  BOOST_CHECK_THROW(builder.set_integer_individual_field(header.field_index("GT"), 0, vector<int32_t>{0, 1}), invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE( set_individual_fields_both_in_bulk_and_by_sample ) {


### PR DESCRIPTION
Now that genotype encoding has been encapsulated within VariantBuilder,
setting GT using a generic integer setter no longer works.

Resolves #387
