### PR TITLE
Remove links that decayed and turned into Spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-[![Build Status](https://travis-ci.org/broadinstitute/gamgee.svg?branch=master)](https://travis-ci.org/broadinstitute/gamgee)
+[![Build Status](https://travis-ci.com/broadinstitute/gamgee.svg?branch=master)](https://travis-ci.com/broadinstitute/gamgee)
 [![Coverage Status](https://coveralls.io/repos/broadinstitute/gamgee/badge.png)](https://coveralls.io/r/broadinstitute/gamgee)
-[![Issue Stats](http://issuestats.com/github/broadinstitute/gamgee/badge/pr)](http://issuestats.com/github/broadinstitute/gamgee)
-[![Issue Stats](http://issuestats.com/github/broadinstitute/gamgee/badge/issue)](http://issuestats.com/github/broadinstitute/gamgee)
 
 # NOTE: gamgee is no longer under active development.  We are leaving the code available as-is, but we have no plans to support or maintain it.
 


### PR DESCRIPTION
* Removing links that have decayed and been replaced by a web-squatting spam site.